### PR TITLE
Add create directory feature to merkle dist script

### DIFF
--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -23,6 +23,11 @@ async function main() {
   )
   const merkleDist = stakingRewards.genMerkleDist(merkleInput)
 
+  fs.mkdir(distribution_path, (err) => {
+    if (err) {
+      return console.error(err)
+    }
+  })
   fs.writeFileSync(
     distribution_path + "/MerkleInputOngoingRewards.json",
     JSON.stringify(ongoingRewards, null, 4)


### PR DESCRIPTION
If the directory where the newly generated Merkle distribution will be created doesn't exist, now it will be created.