### PR TITLE
Fix ongoing rewards miscalculation

### DIFF
--- a/src/stakingrewards/stakingrewards.js
+++ b/src/stakingrewards/stakingrewards.js
@@ -308,12 +308,15 @@ exports.getOngoingMekleInput = async function (
           ? parseInt(epochStake.epochDuration)
           : currentTime - epochStake.epochTimestamp
 
-        // If the operator was confirmed in the middle of this epoch...
         if (
+          // If the operator was confirmed in the middle of this epoch...
           opConfTimestamp > epochTimestamp &&
           opConfTimestamp <= epochTimestamp + epochDuration
         ) {
           epochDuration = epochTimestamp + epochDuration - opConfTimestamp
+        } else if (opConfTimestamp >= epochTimestamp + epochDuration) {
+          // No rewards if the operator was not yet confirmed
+          epochDuration = 0
         }
 
         epochReward = stakeAmount


### PR DESCRIPTION
The operator's confirmation timestamp has not been properly taken into
account: in those epochs in which the operator has not been yet confirmed,
the earned rewards should be zero. However, up to now, these epochs
were also generating ongoing rewards.