### PR TITLE
Add pagination to subgraph queries

### DIFF
--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -4,7 +4,7 @@ const fs = require("fs")
 const stakingRewards = require("../src/stakingrewards/stakingrewards.js")
 
 const graphqlApi =
-  "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.6"
+  "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.7"
 const startTime = 1654041600  // Jun 1st 2022 00:00:00 GMT
 const endTime = 1664496000    // Sep 30th 2022 00:00:00 GMT
 const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)

--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -11,6 +11,13 @@ const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)
 const distribution_path = "distributions/" + endTimeDate
 
 async function main() {
+  try {
+    fs.mkdirSync(distribution_path)
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
   const ongoingRewards = await stakingRewards.getOngoingMekleInput(
     graphqlApi,
     startTime,
@@ -23,27 +30,27 @@ async function main() {
   )
   const merkleDist = stakingRewards.genMerkleDist(merkleInput)
 
-  fs.mkdir(distribution_path, (err) => {
-    if (err) {
-      return console.error(err)
-    }
-  })
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputOngoingRewards.json",
-    JSON.stringify(ongoingRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputBonusRewards.json",
-    JSON.stringify(bonusRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputTotalRewards.json",
-    JSON.stringify(merkleInput, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleDist.json",
-    JSON.stringify(merkleDist, null, 4)
-  )
+  try{
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputOngoingRewards.json",
+      JSON.stringify(ongoingRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputBonusRewards.json",
+      JSON.stringify(bonusRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputTotalRewards.json",
+      JSON.stringify(merkleInput, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleDist.json",
+      JSON.stringify(merkleDist, null, 4)
+    )
+  } catch (err) {
+    console.error(err)
+    return
+  }
 
   console.log("Total amount of rewards: ", merkleDist.totalAmount)
 }


### PR DESCRIPTION
**Note: this PR must be merged after #31** 

Since there is a 1000 elements limit per entity to data retrieved by a
subgraph GraphQL query, if in any moment any query reach this limit,
elements exceeding this limit will be missed, and the calculation of
rewards for merkle distribution will not be correct.

The proposed solution here is to retrieves all the elements in batchs
of 1000 elements.

This PR solves #23 