### PR TITLE
Add staking history script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a Hardhat project:
 - `scripts`: Hardhat scripts:
   - `gen_merkle_dist.js`: generate new Merkle distribution
   - `verify_proof.js`: verify Merkle proof
+  - `stake_history.js`: fetch the information of a particular staker, including staking history.
   - `claim_example.js`: example about how to claim tokens using the contract
 
 ## Examples
@@ -47,6 +48,7 @@ npx hardhat test
 ```
 
 ## Deploy
+
 To deploy to the Ropsten test network you will need a `.env` that looks similar to:
 
 ```
@@ -56,6 +58,7 @@ MAINNET_ETHERSCAN_KEY="M5xxxxxxxxxxxxxxxxxxxxxxxxxxxxxSMV"
 ```
 
 You can then run
+
 ```bash
 npx hardhat --network ropsten deploy
 ```
@@ -63,7 +66,9 @@ npx hardhat --network ropsten deploy
 The contract will be deployed and the source code will be verified on etherscan.
 
 ## Test Deployment
+
 In order to run a test deployment:
+
 ```bash
 npx hardhat --network mainnet_test deploy
 ```

--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -4,7 +4,7 @@ const fs = require("fs")
 const stakingRewards = require("../src/stakingrewards/stakingrewards.js")
 
 const graphqlApi =
-  "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.6"
+  "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.7"
 const startTime = 1654041600  // Jun 1st 2022 00:00:00 GMT
 const endTime = 1664496000    // Sep 30th 2022 00:00:00 GMT
 const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)

--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -11,6 +11,13 @@ const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)
 const distribution_path = "distributions/" + endTimeDate
 
 async function main() {
+  try {
+    fs.mkdirSync(distribution_path)
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
   const ongoingRewards = await stakingRewards.getOngoingMekleInput(
     graphqlApi,
     startTime,
@@ -23,27 +30,27 @@ async function main() {
   )
   const merkleDist = stakingRewards.genMerkleDist(merkleInput)
 
-  fs.mkdir(distribution_path, (err) => {
-    if (err) {
-      return console.error(err)
-    }
-  })
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputOngoingRewards.json",
-    JSON.stringify(ongoingRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputBonusRewards.json",
-    JSON.stringify(bonusRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputTotalRewards.json",
-    JSON.stringify(merkleInput, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleDist.json",
-    JSON.stringify(merkleDist, null, 4)
-  )
+  try{
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputOngoingRewards.json",
+      JSON.stringify(ongoingRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputBonusRewards.json",
+      JSON.stringify(bonusRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputTotalRewards.json",
+      JSON.stringify(merkleInput, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleDist.json",
+      JSON.stringify(merkleDist, null, 4)
+    )
+  } catch (err) {
+    console.error(err)
+    return
+  }
 
   console.log("Total amount of rewards: ", merkleDist.totalAmount)
 }

--- a/scripts/stake_history.js
+++ b/scripts/stake_history.js
@@ -1,0 +1,23 @@
+// Script that retrieves the information of a particular staker, including the staking history
+//Use: node scripts/stake_history.js <staking provider address>
+
+const stakingRewards = require("../src/stakingrewards/stakingrewards.js")
+
+const graphqlApi =
+  "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.7"
+
+async function main() {
+  const args = process.argv.slice(2)
+  const stakingProvAddress = args[0]
+
+  const stakeHistory = await stakingRewards.getStakingHistory(
+    graphqlApi,
+    stakingProvAddress
+  )
+
+  console.log(JSON.stringify(stakeHistory, null, 2))
+}
+
+;(async () => {
+  await main()
+})()


### PR DESCRIPTION
**Note: this PR must be merged after #28**

This script retrieves from subgraph the information of a particular
staker, including the staking history: owner address, operator address,
timestamp of staking events (staked, topped-up, unstaked), and more
data.

This could be a very useful tool to check rewards calculation of stakes, stake information, etc.