### PR TITLE
Add 'try catch' statements to writing disk commands

### DIFF
--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -11,6 +11,13 @@ const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)
 const distribution_path = "distributions/" + endTimeDate
 
 async function main() {
+  try {
+    fs.mkdirSync(distribution_path)
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
   const ongoingRewards = await stakingRewards.getOngoingMekleInput(
     graphqlApi,
     startTime,
@@ -23,27 +30,27 @@ async function main() {
   )
   const merkleDist = stakingRewards.genMerkleDist(merkleInput)
 
-  fs.mkdir(distribution_path, (err) => {
-    if (err) {
-      return console.error(err)
-    }
-  })
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputOngoingRewards.json",
-    JSON.stringify(ongoingRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputBonusRewards.json",
-    JSON.stringify(bonusRewards, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleInputTotalRewards.json",
-    JSON.stringify(merkleInput, null, 4)
-  )
-  fs.writeFileSync(
-    distribution_path + "/MerkleDist.json",
-    JSON.stringify(merkleDist, null, 4)
-  )
+  try{
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputOngoingRewards.json",
+      JSON.stringify(ongoingRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputBonusRewards.json",
+      JSON.stringify(bonusRewards, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleInputTotalRewards.json",
+      JSON.stringify(merkleInput, null, 4)
+    )
+    fs.writeFileSync(
+      distribution_path + "/MerkleDist.json",
+      JSON.stringify(merkleDist, null, 4)
+    )
+  } catch (err) {
+    console.error(err)
+    return
+  }
 
   console.log("Total amount of rewards: ", merkleDist.totalAmount)
 }


### PR DESCRIPTION
'try catch' statement will handle errors like "Directory already exists". Also, the check of mkdir is located now at the beggining of the script, reducing the probability of not being able to save the data queried to subgraph.