### PR TITLE
Integrate tBTCv2 rewards generation script

### DIFF
--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -25,15 +25,13 @@ async function main() {
   let bonusRewards = {}
   let ongoingRewards = {}
   let tbtcv2Rewards = {}
-  const startDate = new Date(startTime * 1000).toISOString().slice(0, 10)
   const endDate = new Date(endTime * 1000).toISOString().slice(0, 10)
   const distPath = `distributions/${endDate}`
   const lastDistPath = `distributions/${lastDistribution}`
   const tbtcv2Script =
   `./rewards.sh ` +
-  `--rewards-start-date ${startDate} ` +
-  `--rewards-end-date ${endDate} ` +
-  `--rewards-json ./rewards.json ` +
+  `--rewards-start-date ${startTime} ` +
+  `--rewards-end-date ${endTime} ` +
   `--etherscan-token ${process.env.ETHERSCAN_TOKEN}`
 
   try {

--- a/scripts/gen_merkle_dist.js
+++ b/scripts/gen_merkle_dist.js
@@ -1,56 +1,119 @@
 // Script that generates a new Merkle Distribution and outputs the data to JSON files
 
 const fs = require("fs")
+const shell = require("shelljs")
+const dotenv = require("dotenv").config()
 const Subgraph = require("../src/stakingrewards/subgraph.js")
 const Rewards = require("../src/stakingrewards/rewards.js")
 const MerkleDist = require("../src/stakingrewards/merkle_dist.js")
 
+const bonusWeight = 0.0
+const ongoingWeight = 0.875
+const tbtcv2Weight = 0.125
+const startTime = 1664496000 // Sep 30th 2022 00:00:00 GMT
+const endTime = 1667260800 // Nov 1st 2022 00:00:00 GMT
+const lastDistribution = "2022-09-30"
+
+const tbtcv2ScriptPath = "src/tbtcv2-rewards/"
 const graphqlApi =
   "https://api.studio.thegraph.com/query/24143/main-threshold-subgraph/0.0.7"
-const bonusWeight = 1.0 // Stakes receive the full bonus
-const ongoingWeight = 1.0 // Stakes receive the full ongoing rewards
-const startTime = 1654041600 // Jun 1st 2022 00:00:00 GMT
-const endTime = 1664496000 // Sep 30th 2022 00:00:00 GMT
-const endTimeDate = new Date(endTime * 1000).toISOString().slice(0, 10)
-const distribution_path = "distributions/" + endTimeDate
 
 async function main() {
+  let earnedBonusRewards = {}
+  let earnedOngoingRewards = {}
+  let earnedTbtcv2Rewards = {}
+  let bonusRewards = {}
+  let ongoingRewards = {}
+  let tbtcv2Rewards = {}
+  const startDate = new Date(startTime * 1000).toISOString().slice(0, 10)
+  const endDate = new Date(endTime * 1000).toISOString().slice(0, 10)
+  const distPath = `distributions/${endDate}`
+  const lastDistPath = `distributions/${lastDistribution}`
+  const tbtcv2Script =
+  `./rewards.sh ` +
+  `--rewards-start-date ${startDate} ` +
+  `--rewards-end-date ${endDate} ` +
+  `--rewards-json ./rewards.json ` +
+  `--etherscan-token ${process.env.ETHERSCAN_TOKEN}`
+
   try {
-    fs.mkdirSync(distribution_path)
+    fs.mkdirSync(distPath)
   } catch (err) {
     console.error(err)
     return
   }
 
-  const ongoingStakes = await Subgraph.getOngoingStakes(
-    graphqlApi,
-    startTime,
-    endTime
-  )
-  const ongoingRewards = await Rewards.calculateOngoingRewards(ongoingStakes, ongoingWeight)
-  const bonusStakes = await Subgraph.getBonusStakes(graphqlApi)
-  const bonusRewards = Rewards.calculateBonusRewards(bonusStakes, bonusWeight)
-  const merkleInput = MerkleDist.combineMerkleInputs(
-    ongoingRewards,
-    bonusRewards
-  )
-  const merkleDist = MerkleDist.genMerkleDist(merkleInput)
+  if (bonusWeight > 0) {
+    console.log("Calculating bonus rewards...")
+    const bonusStakes = await Subgraph.getBonusStakes(graphqlApi)
+    earnedBonusRewards = Rewards.calculateBonusRewards(bonusStakes, bonusWeight)
+  }
 
-  try{
-    fs.writeFileSync(
-      distribution_path + "/MerkleInputOngoingRewards.json",
-      JSON.stringify(ongoingRewards, null, 4)
+  if (ongoingWeight > 0) {
+    console.log("Calculating ongoing rewards...")
+    const ongoingStakes = await Subgraph.getOngoingStakes(
+      graphqlApi,
+      startTime,
+      endTime
     )
+    earnedOngoingRewards = await Rewards.calculateOngoingRewards(
+      ongoingStakes,
+      ongoingWeight
+    )
+  }
+
+  if (tbtcv2Weight > 0) {
+    console.log("Calculating tBTCv2 rewards...")
+    shell.exec(`cd ${tbtcv2ScriptPath} && ${tbtcv2Script}`)
+    const tbtcv2RewardsRaw = JSON.parse(
+      fs.readFileSync("./src/tbtcv2-rewards/rewards.json")
+    )
+    earnedTbtcv2Rewards = Rewards.calculateTbtcv2Rewards(
+      tbtcv2RewardsRaw,
+      tbtcv2Weight
+    )
+  }
+
+  try {
+    bonusRewards = JSON.parse(fs.readFileSync(`${lastDistPath}/MerkleInputBonusRewards.json`))
+    bonusRewards = MerkleDist.combineMerkleInputs(bonusRewards, earnedBonusRewards)
     fs.writeFileSync(
-      distribution_path + "/MerkleInputBonusRewards.json",
+      distPath + "/MerkleInputBonusRewards.json",
       JSON.stringify(bonusRewards, null, 4)
     )
+    ongoingRewards = JSON.parse(fs.readFileSync(`${lastDistPath}/MerkleInputOngoingRewards.json`))
+    ongoingRewards = MerkleDist.combineMerkleInputs(ongoingRewards, earnedOngoingRewards)
     fs.writeFileSync(
-      distribution_path + "/MerkleInputTotalRewards.json",
+      distPath + "/MerkleInputOngoingRewards.json",
+      JSON.stringify(ongoingRewards, null, 4)
+    )
+    if(fs.existsSync(`${lastDistPath}/MerkleInputTbtcv2Rewards.json`)) {
+      tbtcv2Rewards = JSON.parse(fs.readFileSync(`${lastDistPath}/MerkleInputTbtcv2Rewards.json`))
+    } else {
+      tbtcv2Rewards = {}
+    }
+    tbtcv2Rewards = MerkleDist.combineMerkleInputs(tbtcv2Rewards, earnedTbtcv2Rewards)
+    fs.writeFileSync(
+      distPath + "/MerkleInputTbtcv2Rewards.json",
+      JSON.stringify(earnedTbtcv2Rewards, null, 4)
+    )
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
+  let merkleInput = MerkleDist.combineMerkleInputs(bonusRewards, ongoingRewards)
+  merkleInput = MerkleDist.combineMerkleInputs(merkleInput, tbtcv2Rewards)
+
+  const merkleDist = MerkleDist.genMerkleDist(merkleInput)
+
+  try {
+    fs.writeFileSync(
+      distPath + "/MerkleInputTotalRewards.json",
       JSON.stringify(merkleInput, null, 4)
     )
     fs.writeFileSync(
-      distribution_path + "/MerkleDist.json",
+      distPath + "/MerkleDist.json",
       JSON.stringify(merkleDist, null, 4)
     )
   } catch (err) {

--- a/src/stakingrewards/rewards.js
+++ b/src/stakingrewards/rewards.js
@@ -51,3 +51,18 @@ exports.calculateOngoingRewards = function (stakes, weight) {
   })
   return ongoingRewards
 }
+
+/**
+ * Calculate the tBTCv2 weighted rewards earned by each stake
+ * @param {Object} stakes     Stakes with staked T amount
+ * @param {Number} weight     The weight of this type of reward
+ * @return {Object}           The stakes including reward amount
+ */
+exports.calculateTbtcv2Rewards = function (stakes, weight) {
+  Object.keys(stakes).map((stakingProvider) => {
+    const amount = BigNumber(stakes[stakingProvider].amount)
+    const weightedReward = amount.times(weight)
+    stakes[stakingProvider].amount = weightedReward.toFixed(0)
+  })
+  return stakes
+}

--- a/src/tbtcv2-rewards/rewards.ts
+++ b/src/tbtcv2-rewards/rewards.ts
@@ -401,8 +401,8 @@ export async function calculateRewards() {
     operatorsData.push(operatorData);
   }
 
-  console.log("operatorsData: ", JSON.stringify(operatorsData, null, 2));
-  console.log("rewardsData: ", JSON.stringify(rewardsData, null, 4));
+  // console.log("operatorsData: ", JSON.stringify(operatorsData, null, 2));
+  // console.log("rewardsData: ", JSON.stringify(rewardsData, null, 4));
   fs.writeFileSync(rewardsDataOutput, JSON.stringify(rewardsData, null, 4));
 }
 


### PR DESCRIPTION
With this integration the way that 'bonus' and 'ongoing' rewards are calculated is changing also.

Now, instead of calculate the rewards from the start of rewards period (Jun 1st 2022), which requires heavy queries to subgraph and etherscan, and long processing times, the rewards are calculated using the previous distribution. Only the stake data of the new distribution period is queried, and the rewards calculated using only this period are added to the previous reward amounts.