### PR TITLE
Fix stake history script when no operator

### DIFF
--- a/src/pre-rewards/subgraph.js
+++ b/src/pre-rewards/subgraph.js
@@ -567,13 +567,17 @@ exports.getStakingHistory = async function (gqlUrl, stakingProvider) {
     .then((result) => {
       if (result.error) console.error(result.error)
       const data = result.data.simplePREApplication
-      stakeData.operator.operator = data.operator
-      stakeData.operator.bondedDate = new Date(
-        data.bondedTimestamp * 1000
-      ).toISOString()
-      stakeData.operator.confirmedDate = new Date(
-        data.confirmedTimestamp * 1000
-      ).toISOString()
+      if (!data) {
+        stakeData.operator = null
+      } else {
+        stakeData.operator.operator = data.operator
+        stakeData.operator.bondedDate = new Date(
+          data.bondedTimestamp * 1000
+        ).toISOString()
+        stakeData.operator.confirmedDate = new Date(
+          data.confirmedTimestamp * 1000
+        ).toISOString()
+      }
     })
 
   do {


### PR DESCRIPTION
This change fix the following bug: when no operator confirmed for a staking provider, the script stop working instead of showing a null operator message.