### PR TITLE
Fix dump of MerkleInputTbtcv2Rewards JSON

### DIFF
--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -111,7 +111,7 @@ async function main() {
     )
     fs.writeFileSync(
       distPath + "/MerkleInputTbtcv2Rewards.json",
-      JSON.stringify(earnedTbtcv2Rewards, null, 4)
+      JSON.stringify(tbtcv2Rewards, null, 4)
     )
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
This change fixes the bug that causes that the JSON generated during the Merkle distribution generation related to tBTCv2 rewards contains the tBTCv2 rewards earned since the last distribution instead of the total amount of tBTCv2 rewards earned during all the time.