### PR TITLE
Making calculation of periodic rate more precise

### DIFF
--- a/src/tbtcv2-rewards/rewards-constants.ts
+++ b/src/tbtcv2-rewards/rewards-constants.ts
@@ -14,3 +14,4 @@ export const QUERY_RESOLUTION = 60 // 1min sampling time for the metrics
 export const HUNDRED = 100
 export const IS_VERSION_SATISFIED = "isVersionSatisfied"
 export const APR = 15 // percent
+export const SECONDS_IN_YEAR = 31536000


### PR DESCRIPTION
Instead of calculating the general monthly rate of `APR/12` we should calculate the periodic rate with better precision just like the rest of the rewards calculations. tBTCv2 should calculate the periodic rate based on the start and end timestamps of the rewards interval.