### PR TITLE
Build version req fix

### DIFF
--- a/src/tbtcv2-rewards/rewards-constants.ts
+++ b/src/tbtcv2-rewards/rewards-constants.ts
@@ -15,3 +15,4 @@ export const HUNDRED = 100
 export const IS_VERSION_SATISFIED = "isVersionSatisfied"
 export const APR = 15 // percent
 export const SECONDS_IN_YEAR = 31536000
+export const PROMETHEUS_SAMPLING_TOLERANCE = 1800 // 30min

--- a/src/tbtcv2-rewards/rewards.ts
+++ b/src/tbtcv2-rewards/rewards.ts
@@ -113,7 +113,9 @@ export async function calculateRewards() {
 
   const rewardsInterval = endRewardsTimestamp - startRewardsTimestamp
   // periodic rate rounded and adjusted because BigNumber can't operate on floating numbers.
-  const periodicRate = Math.round(APR * (rewardsInterval / SECONDS_IN_YEAR) * PRECISION)
+  const periodicRate = Math.round(
+    APR * (rewardsInterval / SECONDS_IN_YEAR) * PRECISION
+  )
   const currentBlockNumber = await provider.getBlockNumber()
 
   // Query for bootstrap data that has peer instances grouped by operators

--- a/src/tbtcv2-rewards/rewards.ts
+++ b/src/tbtcv2-rewards/rewards.ts
@@ -34,6 +34,7 @@ import {
   HUNDRED,
   APR,
   SECONDS_IN_YEAR,
+  PROMETHEUS_SAMPLING_TOLERANCE,
 } from "./rewards-constants"
 
 program
@@ -362,7 +363,14 @@ export async function calculateRewards() {
         allowedDelayEndTimestamp = endRewardsTimestamp
       }
 
-      if (latestRegisteredBuildVersionTimestmap <= allowedDelayEndTimestamp) {
+      // It might happen that the 'latestRegisteredBuildVersionTimestmap' will
+      // exceed the end of the rewards interval timestamp by 1-15min because of
+      // the Prometheus sampling. For this check, we need to adjust for the Prometheus
+      // sampling and add 30min just to be on the safe side.
+      if (
+        latestRegisteredBuildVersionTimestmap <=
+        allowedDelayEndTimestamp + PROMETHEUS_SAMPLING_TOLERANCE
+      ) {
         // A client's version can be on either 2 latest versions
         requirements.set(
           IS_VERSION_SATISFIED,


### PR DESCRIPTION
It might happen that at the end of the rewards interval when we check the
timestamp of the latest registered client build version Prometheus will
return a timestamp that goes pass the interval. E.g. instead of Feb 1, 2023
00:00:00 it will return Feb 1, 2023 00:01:00 which results in checking
only the latest build version instead of the latest and second to latest. To
mitigate this issue, we add a 30min tolerance when we check against the latest
registered build timestamp.