### PR TITLE
Replace the tags fetching to create temp remotes

### DIFF
--- a/src/tbtcv2-rewards/rewards.sh
+++ b/src/tbtcv2-rewards/rewards.sh
@@ -152,9 +152,10 @@ printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
 yarn install
 
 printf "${LOG_START}Retrieving client release tags...${LOG_END}"
-merkleDistributionRepo=$(git remote get-url origin)
-git remote set-url origin ${KEEP_CORE_REPO}
-git fetch --all --tags --prune
+# Create a new git remote to fetch the release tags
+git remote remove keep-core-repo 2>/dev/null || true
+git remote add keep-core-repo ${KEEP_CORE_REPO}
+git fetch --tags --prune --quiet keep-core-repo
 allTags=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]*'))
 latestTag=${allTags[0]}
 latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]*' --format '%(creatordate:unix)' | head -n 1))
@@ -172,8 +173,8 @@ tagsInRewardInterval+=($secondToLatestTagTimestamp)
 printf -v tags '%s|' "${tagsInRewardInterval[@]}"
 tagsTrimmed="${tags%?}" # remove "|" at the end
 
-# Setting remote back to merkle distribution repo
-git remote set-url origin $merkleDistributionRepo
+# Removing created remote
+git remote remove keep-core-repo
 
 # Run script
 printf "${LOG_START}Fetching peers data...${LOG_END}"


### PR DESCRIPTION
The tBTCv2 node client releases are collected fetching the git tags
created for each release in keep-core repo.

Up to now, the strategy to fetch these tags located on a different repo
is to set the URL of the `origin` remote to keep-core's one and run
`git fetch`. This strategy may lead to several problems:

- If the script fails before the statement that returns the original URL
  to `origin` remote, this remote will keep the new keep-core repo URL,
  which can cause future troubles.
- If you have a different configuration of remotes without a remote
  called `origin`, the tBTCv2 rewards calculation script fails.

The proposed changes modify the strategy: a new remote is created with
keep-core URL and tags are fetched from there. After calculating the
rewards, this new remote is removed.