### PR TITLE
Filtering tags that ends with -m<version>

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -156,14 +156,14 @@ printf "${LOG_START}Retrieving client release tags...${LOG_END}"
 git remote remove keep-core-repo 2>/dev/null || true
 git remote add keep-core-repo ${KEEP_CORE_REPO}
 git fetch --tags --prune --quiet keep-core-repo
-allTags=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]*'))
+allTags=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]'))
 latestTag=${allTags[0]}
-latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]*' --format '%(creatordate:unix)' | head -n 1))
+latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 1))
 latestTagTimestamp="${latestTag}_$latestTimestamp"
 
 # There are at least 2 tags available at this point of time
 secondToLatestTag=${allTags[1]}
-secondToLatestTagTimestamp="${secondToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]*' --format '%(creatordate:unix)' | head -n 2 | tail -1)"
+secondToLatestTagTimestamp="${secondToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 2 | tail -1)"
 
 tagsInRewardInterval=()
 tagsInRewardInterval+=($latestTagTimestamp)


### PR DESCRIPTION
When fetching git tags for rewards calculation, we should take into account only stable versions and ignore e.g. release candidates. Example of correct versions:
- v2.0.0-m2
- v2.0.0-m3

Other tags with different postfixes should be ignored, e.g. v2.0.0-m3-rc