### PR TITLE
Lowering uptime req

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -18,7 +18,7 @@ KEEP_CORE_REPO="https://github.com/keep-network/keep-core"
 OCTOBER_17="1666051200" # Oct 18 00:00:00 GMT
 REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
-REQUIRED_UPTIME_DEFAULT=96 # percent
+REQUIRED_UPTIME_DEFAULT=50 # percent
 
 help() {
   echo -e "\nUsage: $0" \


### PR DESCRIPTION
There is an issue with a keep client that might result in errors and affect the uptime requirement in rewards distribution. KEEP team decided to make an exception for the months of Aug and Sep and lower the uptime req to 50% until the fix is merged and a new release is published. It should be enough that every single node meets the uptime req for the month of August.