### PR TITLE
Fix rewards calc when invalid tBTCv2 version

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -381,8 +381,6 @@ export async function calculateRewards() {
             // Instance run on the older version than 2 latest.
             requirements.set(IS_VERSION_SATISFIED, false)
           }
-          // No need to check other instances.
-          break
         }
       }
     } else {


### PR DESCRIPTION
This bug affects the calculation of tBTCv2 staking reward earnings.

One of the requirements to be elegible for tBTCv2 staking rewards is to be running the last version of the tBTCv2 client. When a new version of the client is released, there is an update window in which staker can run either the new or the previous version in order to allow time for updating and maintenance. But in any case it should be possible to run an earlier version than these both.

However, up to now, earlier versions were not been properly checked during the update window. So, nodes that
	1. were running an invalid client version during the current month and
	2. updated to the last client version during the update window may be wrongly considered as eligible for tBTCv2 rewards.

This fix ensures that this requirement is properly checked.