### PR TITLE
Validating all the keep-client versions over the rewards interval

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -378,8 +378,10 @@ export async function calculateRewards() {
               instances[i].buildVersion.includes(secondToLatestClientTag)
             )
           ) {
-            // Instance run on the older version than 2 latest.
             requirements.set(IS_VERSION_SATISFIED, false)
+            // No need to check other instances because at least one instance run
+            // on the older version than 2 latest allowed.
+            break
           }
         }
       }
@@ -404,9 +406,10 @@ export async function calculateRewards() {
         } else {
           if (!instances[i].buildVersion.includes(secondToLatestClientTag)) {
             requirements.set(IS_VERSION_SATISFIED, false)
+            // No need to check other instances because at least one instance run
+            // on the older version than 2 latest allowed.
+            break
           }
-          // No need to check other instances before the latestClientTagTimestamp.
-          break
         }
       }
     }


### PR DESCRIPTION
This is a follow-up fix of PR [#78](https://github.com/threshold-network/merkle-distribution/pull/78). In both cases, a script should validate all the keep-client versions in a given reward interval. If it happens that a client runs an older version that is allowed it should not be eligible for rewards.

In this scenario when a cutoff day for the upgrade enters the next rewards distribution a staker can run either of two latest client versions at any given moment.

No prior distributions were affected.