### PR TITLE
October interval adjustments

### DIFF
--- a/src/scripts/tbtcv2-rewards/README.md
+++ b/src/scripts/tbtcv2-rewards/README.md
@@ -20,7 +20,7 @@ rewards interval
 ## Client build version
 
 Node operators must stay updated with the latest keep-core client releases to
-receive rewards. The cutoff day for a new version is calculated by adding two
+receive rewards. The cutoff day for a new version is calculated by adding three
 weeks to its tag creation date, which can be verified by executing the command
 `git show <tag>`.
 

--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -1,4 +1,7 @@
-export const ALLOWED_UPGRADE_DELAY = 2886195 // exceptional case: new vers announced after 11 days
+// 3 weeks in sec (default value) + we add 6 days becuase the -m5 release was
+// announced 6 days after the tag was created. This applies only for the October
+// rewards interval.
+export const ALLOWED_UPGRADE_DELAY = 2332800
 export const OPERATORS_SEARCH_QUERY_STEP = 600 // 10min in sec
 export const IS_BEACON_AUTHORIZED = "isBeaconAuthorized"
 export const BEACON_AUTHORIZATION = "beaconAuthorization"

--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -18,7 +18,7 @@ KEEP_CORE_REPO="https://github.com/keep-network/keep-core"
 OCTOBER_17="1666051200" # Oct 18 00:00:00 GMT
 REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
-REQUIRED_UPTIME_DEFAULT=50 # percent
+REQUIRED_UPTIME_DEFAULT=60 # percent
 
 help() {
   echo -e "\nUsage: $0" \


### PR DESCRIPTION
These are the adjustments for the October interval, and shouldn't be merged before we distribute the rewards for the September interval. Making it a draft for now.

This PR includes 3 changes:
- modifying 2 -> 3 weeks for the allowed upgrade delay in the README
- adjusted allowed upgrade delay for the October interval
- adjusted uptime req for the October interval

Please see the commit messages for more info.