### PR TITLE
Adding an uptime check for the entire interval

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -666,7 +666,16 @@ async function checkUptime(
     sumUptime += uptime
   }
 
-  const isUptimeSatisfied = sumUptime >= requiredUptime
+  // Uptime is calculated as a sum of uptimes for all the instances while they
+  // were running.
+  const isInstancesUptimeSatisfied = sumUptime >= requiredUptime
+  // Check if the uptime requirement is satisfied for the entire interval
+  const isIntervalUptimeSatisfied =
+    (uptimeSearchRange / rewardsInterval) * HUNDRED >= requiredUptime
+
+  const isUptimeSatisfied =
+    isInstancesUptimeSatisfied && isIntervalUptimeSatisfied
+
   // October is a special month for rewards calculation. If a node was set before
   // October 17th, then it is eligible for the entire month of rewards. Uptime of
   // a running node still need to meet the uptime requirement after it was set.


### PR DESCRIPTION
There was a check that validated an uptime for a given instance but only when an instance was running. This bug gave the nodes hidden slack. A node could spin up and start running only e.g. for 10 days and report 100% uptime, but it was just around 33% of the entire interval. In order to be eligible for rewards, a node should run at least a `requiredUptime` of interval.
In this PR we check not only an uptime of a node while it was running, but also a percentage of an interval it was up. Both values need to be >= `requiredUptime` to get the rewards.