### PR TITLE
Eligible number of build versions

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -19,6 +19,11 @@ OCTOBER_17="1666051200" # Oct 18 00:00:00 GMT
 REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
 REQUIRED_UPTIME_DEFAULT=50 # percent
+# Default should be 2. In rare cases when we release a hot fix and all 3 tags
+# become eligible in a given interval, then it can be set to 3. 
+# Script supports up to 3 tags.
+ELIGIBLE_NUMBER_OF_TAGS=3 
+
 
 help() {
   echo -e "\nUsage: $0" \
@@ -157,6 +162,7 @@ git remote remove keep-core-repo 2>/dev/null || true
 git remote add keep-core-repo ${KEEP_CORE_REPO}
 git fetch --tags --prune --quiet keep-core-repo
 allTags=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]'))
+printf "Found ${allTags[*]} tags"
 latestTag=${allTags[0]}
 latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 1))
 latestTagTimestamp="${latestTag}_$latestTimestamp"
@@ -168,6 +174,12 @@ secondToLatestTagTimestamp="${secondToLatestTag}_$(git tag --sort=-version:refna
 tagsInRewardInterval=()
 tagsInRewardInterval+=($latestTagTimestamp)
 tagsInRewardInterval+=($secondToLatestTagTimestamp)
+
+if [ "$ELIGIBLE_NUMBER_OF_TAGS" -eq "3" ]; then
+  thirdToLatestTag=${allTags[2]}
+  thirdToLatestTagTimestamp="${thirdToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 3 | tail -1)"
+  tagsInRewardInterval+=($thirdToLatestTagTimestamp)
+fi
 
 # Converting array to string so we can pass to the rewards-requirements.ts
 printf -v tags '%s|' "${tagsInRewardInterval[@]}"

--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -14,8 +14,6 @@ REWARDS_JSON_DEFAULT="./rewards.json"
 ETHERSCAN_API_DEFAULT="https://api.etherscan.io"
 NETWORK_DEFAULT="mainnet"
 KEEP_CORE_REPO="https://github.com/keep-network/keep-core"
-# Special October case when calculating rewards
-OCTOBER_17="1666051200" # Oct 18 00:00:00 GMT
 REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
 REQUIRED_UPTIME_DEFAULT=50 # percent
@@ -142,16 +140,8 @@ timestamp=$REWARDS_END_DATE&\
 closest=after&\
 apikey=${ETHERSCAN_TOKEN}"
 
-october17ApiCall="${ETHERSCAN_API}/api?\
-module=block&\
-action=getblocknobytime&\
-timestamp=$OCTOBER_17&\
-closest=after&\
-apikey=${ETHERSCAN_TOKEN}"
-
 startRewardsBlock=$(curl -s $startBlockApiCall | jq '.result|tonumber')
 endRewardsBlock=$(curl -s $endBlockApiCall | jq '.result|tonumber')
-october17Block=$(curl -s $october17ApiCall | jq '.result|tonumber')
 
 printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
 yarn install
@@ -198,8 +188,6 @@ ETHERSCAN_TOKEN=${ETHERSCAN_TOKEN} yarn rewards \
   --end-timestamp $REWARDS_END_DATE \
   --start-block $startRewardsBlock \
   --end-block $endRewardsBlock \
-  --october17-block $october17Block \
-  --october17-timestamp $OCTOBER_17 \
   --releases $tagsTrimmed \
   --network ${NETWORK} \
   --output ${REWARDS_JSON} \

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -331,6 +331,14 @@ export async function calculateRewards() {
     const secondToLatestClient = clientReleases[1].split("_")
     const secondToLatestClientTag = secondToLatestClient[0]
 
+    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
+
+    if (clientReleases.length == 3) {
+      const thirdToLatestClient = clientReleases[2].split("_")
+      const thirdToLatestClientTag = thirdToLatestClient[0]
+      eligibleClientTags.push(thirdToLatestClientTag)
+    }
+
     const instances = await processBuildVersions(
       operatorAddress,
       rewardsInterval,
@@ -340,9 +348,11 @@ export async function calculateRewards() {
     const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
     requirements.set(IS_VERSION_SATISFIED, true)
     if (upgradeCutoffDate < startRewardsTimestamp) {
-      // v1-|-------v1 or v2------|------------------v2 only--------------|
+      // E.g. Feb interval
+      // ---older eligible tags---|----------latest tag only--------------|
       // ---|---------------------|---------|-----------------------------|--->
-      //  v2tag                 cutoff     Feb1                          Feb28
+      // latest tag             cutoff     Feb1                         Feb28
+
       // All the instances must run on the latest version during the rewards
       // interval in Feb.
       for (let i = 0; i < instances.length; i++) {
@@ -351,9 +361,11 @@ export async function calculateRewards() {
         }
       }
     } else if (upgradeCutoffDate < endRewardsTimestamp) {
-      // -v1-|-------v1 or v2---------|--------v2 only--------|
+      // E.g. Feb interval
+      // -----older eligible tags-----|----latest tag only----|
       // ----|---------|--------------|-----------------------|--->
-      //   v2tag     Feb1          cutoff                  Feb28
+      // latest tag   Feb1          cutoff                   Feb28
+
       // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
       // must run on the latest version
       for (let i = instances.length - 1; i >= 0; i--) {
@@ -372,12 +384,7 @@ export async function calculateRewards() {
           // upgrade cutoff date that happens to be right before the interval
           // end date. However, it might still be eligible for rewards because
           // of the uptime requirement.
-          if (
-            !(
-              instances[i].buildVersion.includes(latestClientTag) ||
-              instances[i].buildVersion.includes(secondToLatestClientTag)
-            )
-          ) {
+          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
             requirements.set(IS_VERSION_SATISFIED, false)
             // No need to check other instances because at least one instance run
             // on the older version than 2 latest allowed.
@@ -386,30 +393,19 @@ export async function calculateRewards() {
         }
       }
     } else {
-      // ------------v1------------|-----------v1 or v2---------|---v2 only--->
+      // E.g. Feb interval
+      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
       // --|-----------------------|---------------|------------|-->
-      //  Feb1                   v2tag           Feb28        cutoff
-      // All the instances between [latestClientTagTimestamp : endRewardsTimestamp]
-      // must run either on secondToLatest or the latest version
+      //  Feb1                latest tag         Feb28        cutoff
+
+      // For simplicity purposes all the instances can run on any of the eligible
+      // versions.
       for (let i = instances.length - 1; i >= 0; i--) {
-        if (instances[i].lastRegisteredTimestamp >= latestClientTagTimestamp) {
-          if (
-            !(
-              instances[i].buildVersion.includes(latestClientTag) ||
-              instances[i].buildVersion.includes(secondToLatestClientTag)
-            )
-          ) {
-            // A client run a version older than 2 latest allowed. No rewards.
-            requirements.set(IS_VERSION_SATISFIED, false)
-            break
-          }
-        } else {
-          if (!instances[i].buildVersion.includes(secondToLatestClientTag)) {
-            requirements.set(IS_VERSION_SATISFIED, false)
-            // No need to check other instances because at least one instance run
-            // on the older version than 2 latest allowed.
-            break
-          }
+        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+          requirements.set(IS_VERSION_SATISFIED, false)
+          // No need to check other instances because at least one instance run
+          // on a version that is no longer eligible in this rewards interval.
+          break
         }
       }
     }

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -490,20 +490,6 @@ async function getAuthorization(
 //  Sep 18 - 30 constant 100k (last sub-interval)
 // Weighted authorization = (3-0)/30*100 + (8-3)/30*110 + (14-8)/30*135
 //                        + (18-14)/30*120 + (30-18)/30*100
-// October 2022 is a special month for rewards calculation.  If a node was set
-// after Oct 1 but prior to Oct 17, then we calculate the rewards for the entire
-// month.
-// See https://blog.threshold.network/tbtc-v2-hits-its-first-launch-milestone/
-// E.g. 1
-// First and only event was on Oct 10. The authorization is calculated for the
-// entire month.
-// E.g. 2
-// First increase event was on Oct 10 from 0 to 100k
-// Second increase was on Oct 15 from 100k to 150k
-// Authorization of 100k is interpolated for the dates between Oct 1 - Oct 10
-// Authorization for Oct 1 - Oct 15 is now 100k; coefficient 15/30
-// Authorization between Oct 15 - Oct 30 is 150k; coefficent 15/30
-// Weighted authorization: 15/30 * 100k + 15/30 * 150k
 function authorizationForRewardsInterval(
   intervalEvents: any[],
   startRewardsBlock: number,


### PR DESCRIPTION
For simplicity purposes, we supported only 2 keep client release tags in a given interval. In rare cases when we need to release a hotfix it might happen that in a given interval 3 keep client versions will be eligible, just like for October 2023 interval. This PR adds support for a third release. However, the default number of tags should be set to 2, only in rare cases the number should be bumped up to 3, i.e. when 3 tags are eligible to run in a given interval.

**Important**! After the October interval rewards are calculated, the `ELIGIBLE_NUMBER_OF_TAGS` should be changed to `2`

TODO:
- [ ] `ALLOWED_UPGRADE_DELAY` will need to be adjusted, because `-m6` tag was already created but not announced. We count 3 weeks from the day of the announcement.

Also, this PR includes a cleanup of the Oct 17 2023 case. This scenario is no longer needed to be supported by these scripts.
