### PR TITLE
Include `m6` announcement drift within the allowed upgrade delay

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -1,7 +1,7 @@
-// 3 weeks in sec (default value) + we add 6 days becuase the -m5 release was
-// announced 6 days after the tag was created. This applies only for the October
-// rewards interval.
-export const ALLOWED_UPGRADE_DELAY = 2332800
+// 3 weeks in sec (default value) + we add 20 days because the -m6 release was
+// announced 20 days after the tag was created. This applies only for the October
+// and November rewards interval (cutoff date for -m6 is Nov 15).
+export const ALLOWED_UPGRADE_DELAY = 3542400
 export const OPERATORS_SEARCH_QUERY_STEP = 600 // 10min in sec
 export const IS_BEACON_AUTHORIZED = "isBeaconAuthorized"
 export const BEACON_AUTHORIZATION = "beaconAuthorization"

--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -1,7 +1,7 @@
-// 3 weeks in sec (default value) + we add 20 days because the -m6 release was
-// announced 20 days after the tag was created. This applies only for the October
+// 3 weeks in sec (default value) + we add 22,67 days because the -m6 release was
+// announced 22,67 days after the tag was created. This applies only for the October
 // and November rewards interval (cutoff date for -m6 is Nov 15).
-export const ALLOWED_UPGRADE_DELAY = 3542400
+export const ALLOWED_UPGRADE_DELAY = 3773887
 export const OPERATORS_SEARCH_QUERY_STEP = 600 // 10min in sec
 export const IS_BEACON_AUTHORIZED = "isBeaconAuthorized"
 export const BEACON_AUTHORIZATION = "beaconAuthorization"


### PR DESCRIPTION
The `m6` release was announced 20 days after the tag was published on GitHub. That means we need to extend the default allowed upgrade delay (3 weeks) to take that additional delay into account. The new allowed upgrade delay is 41 days. That means the cutoff day for `m6` is November 15. The modified allowed upgrade delay should remain in force for October and November rewards intervals. We should bring it back to the default value of 3 weeks for December interval.