### PR TITLE
Support Sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,18 @@ npx hardhat test
 
 ## Deploy
 
-To deploy to the Goerli test network you will need a `.env` that looks similar to:
+To deploy to the Sepolia test network you will need a `.env` that looks similar to:
 
 ```
-GOERLI_RPC_URL="https://goerli.infura.io/v3/bd76xxxxxxxxxxxxxxxxxxxxxxxxxff0"
-GOERLI_PRIVATE_KEY="3d3ad2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx87b"
+SEPOLIA_RPC_URL="https://sepolia.infura.io/v3/bd76xxxxxxxxxxxxxxxxxxxxxxxxxff0"
+SEPOLIA_PRIVATE_KEY="3d3ad2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx87b"
 ETHERSCAN_TOKEN="M5xxxxxxxxxxxxxxxxxxxxxxxxxxxxxSMV"
 ```
 
 You can then run
 
 ```bash
-npx hardhat --network goerli deploy
+npx hardhat --network sepolia deploy
 ```
 
 The contract will be deployed and the source code will be verified on etherscan.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -23,20 +23,24 @@ module.exports = {
   namedAccounts: {
     deployer: {
       goerli: 0,
+      sepolia: 0,
       mainnet: 0,
       mainnet_test: 0,
     },
     rewardsHolder: {
       goerli: "0xCe692F6fA86319Af43050fB7F09FDC43319F7612",
+      sepolia: "0xCe692F6fA86319Af43050fB7F09FDC43319F7612",
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
       mainnet_test: 0,
     },
     tokenContract: {
       goerli: "0x3f16380656cAE45D3f80D8833682d2b606eD094A",
+      sepolia: "0x46abDF5aD1726ba700794539C3dB8fE591854729",
       mainnet: "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
     },
     owner: {
       goerli: 0,
+      sepolia: 0,
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
       mainnet_test: 0,
     },

--- a/hardhat.networks.js
+++ b/hardhat.networks.js
@@ -51,6 +51,15 @@ register(
   "goerli",
   process.env.ETHERSCAN_TOKEN
 )
+register(
+  "sepolia",
+  ["deploy"],
+  11155111,
+  process.env.SEPOLIA_RPC_URL,
+  process.env.SEPOLIA_PRIVATE_KEY,
+  "sepolia",
+  process.env.ETHERSCAN_TOKEN
+)
 
 networks["hardhat"] = {
   forking: {


### PR DESCRIPTION
The Görli testnet currently used by Threshold/Keep for development purposes is planned to become deprecated with the end of year 2023. The testnet that was created to replace it is called
[Holešky](https://github.com/eth-clients/holesky), however it will take some time until it gets integrated with by some of the projects we rely on. As a solution, we decided to switch first to another testnet that is currently live - Sepolia. This testnet's EOL is planned for 2026, which gives us plenty of time to move to Holešky before Sepolia gets deprecated. Until Görli is not dead we want to support both testnets.