### PR TITLE
Remove support for Goerli testnet

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,24 +22,20 @@ module.exports = {
   },
   namedAccounts: {
     deployer: {
-      goerli: 0,
       sepolia: 0,
       mainnet: 0,
       mainnet_test: 0,
     },
     rewardsHolder: {
-      goerli: "0xCe692F6fA86319Af43050fB7F09FDC43319F7612",
       sepolia: "0xCe692F6fA86319Af43050fB7F09FDC43319F7612",
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
       mainnet_test: 0,
     },
     tokenContract: {
-      goerli: "0x3f16380656cAE45D3f80D8833682d2b606eD094A",
       sepolia: "0x46abDF5aD1726ba700794539C3dB8fE591854729",
       mainnet: "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
     },
     owner: {
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
       mainnet_test: 0,

--- a/hardhat.networks.js
+++ b/hardhat.networks.js
@@ -43,15 +43,6 @@ register(
   process.env.ETHERSCAN_TOKEN
 )
 register(
-  "goerli",
-  ["deploy"],
-  3,
-  process.env.GOERLI_RPC_URL,
-  process.env.GOERLI_PRIVATE_KEY,
-  "goerli",
-  process.env.ETHERSCAN_TOKEN
-)
-register(
   "sepolia",
   ["deploy"],
   11155111,


### PR DESCRIPTION
As the Goerli testnet will become deprecated with end of year 2023 and we've already migrated to Sepolia testnet, we'll no longer need the Goerli-related code past that date.

Ref: https://github.com/threshold-network/solidity-contracts/issues/150