### PR TITLE
Return tBTC params uptime and tags to default ones

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -16,11 +16,11 @@ NETWORK_DEFAULT="mainnet"
 KEEP_CORE_REPO="https://github.com/keep-network/keep-core"
 REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
-REQUIRED_UPTIME_DEFAULT=60 # percent
+REQUIRED_UPTIME_DEFAULT=96 # percent
 # Default should be 2. In rare cases when we release a hot fix and all 3 tags
-# become eligible in a given interval, then it can be set to 3. 
+# become eligible in a given interval, then it can be set to 3.
 # Script supports up to 3 tags.
-ELIGIBLE_NUMBER_OF_TAGS=3 
+ELIGIBLE_NUMBER_OF_TAGS=2
 
 help() {
   echo -e "\nUsage: $0" \


### PR DESCRIPTION
Two tBTC requirement parameters had been temporarily modified in previous distributions: see [1], [2] and [3].

This change will return to default values these two parameters.

[1] https://github.com/threshold-network/merkle-distribution/pull/77
[2] https://github.com/threshold-network/merkle-distribution/pull/87
[3] https://github.com/threshold-network/merkle-distribution/pull/94