### PR TITLE
Add support for legacy stakes in tBTC calculations

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -187,9 +187,7 @@ export async function calculateRewards() {
       event.blockNumber < endRewardsBlock
   )
   const postLegacyEvents = legacyEvents.filter(
-    (event) =>
-      event.blockNumber > startRewardsBlock &&
-      event.blockNumber > endRewardsBlock - 1
+    (event) => event.blockNumber > endRewardsBlock - 1
   )
 
   intervalAuthorizationDecreasedEvents =


### PR DESCRIPTION
When legacy stakes (Keep and Nu staking) were deactivated from Threshold staking, the T tokens staked in the contract and that came from the legacy tokens (keepInT, nuInT in the contract) were unstaked.

In addition to this, those legacy tokens that were part of Threshold apps authorizations (walletRegistry, randomBeacon) are no longer part of the authorization amount of the stake.

Since the authorization of these stakes has been decreased, a special event has been emitted for those: "AuthorizationInvoluntaryDecreased".

This event is not supported by the tBTC rewards calculation script, which leads to errors in the calculation of the rewards of some legacy stakes.

This PR adds support for this special event `AuthorizationInvoluntaryDecreased`, which will be treated as an `AuthorizationDecreasedApproved` event.

Transaction in which legacy stakes were disabled:
https://etherscan.io/tx/0x68ddee6b5651d5348a40555b0079b5066d05a63196e3832323afafae0095a656

Transition guide for legacy stakers:
https://forum.threshold.network/t/transition-guide-for-legacy-stakers/719

