### PR TITLE
Fix bug: miscalculation in last epoch duration for PRE rewards

### DIFF
--- a/src/scripts/pre-rewards/subgraph.js
+++ b/src/scripts/pre-rewards/subgraph.js
@@ -291,12 +291,13 @@ exports.getPreStakes = async function (gqlUrl, startTimestamp, endTimestamp) {
   epochs[0].timestamp = startTimestamp.toString()
   epochs[0].duration = (epochs[1].timestamp - startTimestamp).toString()
   const lastEpochIndex = epochs.length - 1 > 0 ? epochs.length - 1 : 0
-  epochs[lastEpochIndex].duration =
+  epochs[lastEpochIndex].duration = (
     endTimestamp - epochs[lastEpochIndex].timestamp
+  ).toString()
 
   // Clean the empty epochs
   epochs = epochs.filter((epoch) => {
-    return epoch.stakes.length > 0
+    return epoch.stakes.length > 0 && epoch.duration !== "0"
   })
 
   // Sort the epoch's stakes by staking provider


### PR DESCRIPTION
The bug is that when the timestamp of the endTime of the rewards distribution coincide with the timestamp of the creation of the last subgraph epoch, the duration of the epoch is miscalculated.