### PR TITLE
Set tBTC client ALLOWED UPGRADE DELAY to default value

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -1,7 +1,4 @@
-// 3 weeks in sec (default value) + we add 22,67 days because the -m6 release was
-// announced 22,67 days after the tag was created. This applies only for the October
-// and November rewards interval (cutoff date for -m6 is Nov 15).
-export const ALLOWED_UPGRADE_DELAY = 3773887
+export const ALLOWED_UPGRADE_DELAY = 1814400 // 3 weeks in sec (default value)
 export const OPERATORS_SEARCH_QUERY_STEP = 600 // 10min in sec
 export const IS_BEACON_AUTHORIZED = "isBeaconAuthorized"
 export const BEACON_AUTHORIZATION = "beaconAuthorization"


### PR DESCRIPTION
This constant was set to the previous value due to the `-m6` release drift between release and announcement. The upgrade period has ended so that we can restore the default value for the next distributions.