### PR TITLE
Add TACo operators' support

### DIFF
--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -9,7 +9,6 @@ const ethers = require("ethers")
 const Subgraph = require("./pre-rewards/subgraph.js")
 const Rewards = require("./pre-rewards/rewards.js")
 const MerkleDist = require("./merkle_dist/merkle_dist.js")
-const BigNumber = require("bignumber.js")
 
 // The following parameters must be modified for each distribution
 const bonusWeight = 0.0
@@ -77,30 +76,7 @@ async function main() {
       endTime
     )
     earnedPreRewards = Rewards.calculatePreRewards(preStakes, preWeight)
-    console.log("======= EARNED PRE REWARDS =======")
-    console.log(earnedPreRewards)
   }
-
-  // Special case: Dec 8th 23 distribution. ###################################
-  // Nov 22nd 23, legacy stakes (i.e. T stakes that originally came from Keep
-  // and Nu staking contracts) were deactivated. There is a period in which
-  // these stakers can migrate to T and stake their tokens without losing the
-  // rewards associated to this migration period.
-  // This period ended for the legacy Nu stakers at Dec 8th 23 00:00.
-  // So, if a legacy stake migrated their legacy Nu (nuInT) tokens before
-  // the deadline, the period in which their tokens weren't staked (Nov 22nd -
-  // Dec 8th) will not be considered, so they will earn the corresponding
-  // rewards as there was no disruption in the staking.
-  //
-  // In addition, no rewards were distributed for stakes that had legacy
-  // staking, even if part of the staking was in tStake and not in legacy stake
-  // (nuInT, keepInT). So
-
-  // More info can be found here:
-  // https://github.com/threshold-network/solidity-contracts/issues/141
-  // https://forum.threshold.network/t/transition-guide-for-legacy-stakers/719
-  // https://etherscan.io/tx/0x68ddee6b5651d5348a40555b0079b5066d05a63196e3832323afafae0095a656
-  // https://github.com/threshold-network/merkle-distribution/pull/111
 
   // We need the legacy stakes to delete the Keep legacy stakes
   const blockNumber = 18624792 // Block height in which legacy stakes were deac
@@ -108,24 +84,6 @@ async function main() {
     graphqlApi,
     blockNumber - 1
   )
-
-  const legacyNuRewards = await Subgraph.getLegacyNuRewards(graphqlApi)
-  console.log("======= LEGACY NU REWARDS =======")
-  console.log(legacyNuRewards)
-
-  Object.keys(legacyNuRewards).map((stake) => {
-    // Caution: we are assuming that each legacyNuReward stake will have the
-    // same stake in earnedPreRewardAmount. This is true for this time
-    const stakeAdd = ethers.utils.getAddress(stake)
-    const earnedPreRewardAmount = BigNumber(earnedPreRewards[stakeAdd].amount)
-    const legacyNuRewardAmount = BigNumber(legacyNuRewards[stake])
-    earnedPreRewards[stakeAdd].amount = earnedPreRewardAmount
-      .plus(legacyNuRewardAmount)
-      .toFixed(0)
-  })
-
-  console.log("======= LEGACY NU + PRE REWARDS =======")
-  console.log(earnedPreRewards)
 
   // tBTCv2 rewards calculation
   if (tbtcv2Weight > 0) {
@@ -138,8 +96,6 @@ async function main() {
       tbtcv2RewardsRaw,
       tbtcv2Weight
     )
-    console.log("======= EARNED TBTC REWARDS BEFORE LEGACY REMOVE =======")
-    console.log(earnedTbtcv2Rewards)
   }
 
   // Delete the Keep legacy stakes in earned rewards
@@ -148,16 +104,10 @@ async function main() {
     delete earnedTbtcv2Rewards[legacyStakeAddress]
   })
 
-  console.log("======= EARNED TBTC REWARDS AFTER LEGACY REMOVE =======")
-  console.log(earnedTbtcv2Rewards)
-
   // Delete the Keep legacy stakes in rewards details file
   const rewardsDetailsPath =
     "distributions/2023-12-08/tBTCv2-rewards-details/1701388800-1701993600.json"
   const rewardsDetails = JSON.parse(fs.readFileSync(rewardsDetailsPath))
-
-  console.log("======= REWARDS DETAILS BEFORE LEGACY REMOVE =======")
-  console.log(JSON.stringify(rewardsDetails, null, 4))
 
   const rewardsDetailsFiltered = rewardsDetails.filter((rewardDetail) => {
     const rewardStakingProvider = Object.keys(rewardDetail)[0].toLowerCase()
@@ -169,9 +119,6 @@ async function main() {
     rewardsDetailsPath,
     JSON.stringify(rewardsDetailsFiltered, null, 4)
   )
-
-  console.log("======= REWARDS DETAILS AFTER LEGACY REMOVE =======")
-  console.log(JSON.stringify(rewardsDetailsFiltered, null, 4))
 
   // Add rewards earned to cumulative totals
   try {

--- a/src/scripts/taco-rewards/taco-rewards.js
+++ b/src/scripts/taco-rewards/taco-rewards.js
@@ -1,0 +1,43 @@
+const { ethers } = require("ethers")
+
+async function getOperatorConfirmedEvent(stakingProvider) {
+  const TACoChildApplicationAdd = "0xFa07aaB78062Fac4C36995bF28F6D677667973F5"
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.POLYGON_RPC_URL
+  )
+  const eventSignature = "OperatorConfirmed(address,address)"
+  const eventTopic = ethers.utils.id(eventSignature)
+  const eventAbi =
+    // eslint-disable-next-line quotes
+    '[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"stakingProvider","type":"address"},{"indexed":true,"internalType":"address","name":"operator","type":"address"}],"name":"OperatorConfirmed","type":"event"}]'
+  const eventIntrfc = new ethers.utils.Interface(eventAbi)
+
+  const rawLogs = await provider.getLogs({
+    address: TACoChildApplicationAdd,
+    topics: [
+      eventTopic,
+      ethers.utils.hexZeroPad(stakingProvider.toLowerCase(), 32),
+    ],
+    fromBlock: 50223997,
+  })
+
+  if (rawLogs.length === 0) {
+    return undefined
+  }
+
+  // Take the most recent Operator confirmed event
+  const log = rawLogs.reduce((acc, val) => {
+    return acc > val ? acc : val
+  })
+  const parsedLog = eventIntrfc.parseLog(log)
+
+  const operatorInfo = {
+    stakingProvider: stakingProvider,
+    operator: parsedLog.args.operator,
+    blockNumber: log.blockNumber,
+  }
+
+  return operatorInfo
+}
+
+module.exports = { getOperatorConfirmedEvent }

--- a/src/scripts/taco-rewards/taco-rewards.js
+++ b/src/scripts/taco-rewards/taco-rewards.js
@@ -1,16 +1,18 @@
 const { ethers } = require("ethers")
 
+const TACoChildApplicationAdd = "0xFa07aaB78062Fac4C36995bF28F6D677667973F5"
+const eventSignature = "OperatorConfirmed(address,address)"
+const eventTopic = ethers.utils.id(eventSignature)
+const eventAbi =
+  // eslint-disable-next-line quotes
+  '[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"stakingProvider","type":"address"},{"indexed":true,"internalType":"address","name":"operator","type":"address"}],"name":"OperatorConfirmed","type":"event"}]'
+
+// Return the operator confirmed event for the provided staking provider
 async function getOperatorConfirmedEvent(stakingProvider) {
-  const TACoChildApplicationAdd = "0xFa07aaB78062Fac4C36995bF28F6D677667973F5"
+  const eventIntrfc = new ethers.utils.Interface(eventAbi)
   const provider = new ethers.providers.JsonRpcProvider(
     process.env.POLYGON_RPC_URL
   )
-  const eventSignature = "OperatorConfirmed(address,address)"
-  const eventTopic = ethers.utils.id(eventSignature)
-  const eventAbi =
-    // eslint-disable-next-line quotes
-    '[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"stakingProvider","type":"address"},{"indexed":true,"internalType":"address","name":"operator","type":"address"}],"name":"OperatorConfirmed","type":"event"}]'
-  const eventIntrfc = new ethers.utils.Interface(eventAbi)
 
   const rawLogs = await provider.getLogs({
     address: TACoChildApplicationAdd,
@@ -40,4 +42,60 @@ async function getOperatorConfirmedEvent(stakingProvider) {
   return operatorInfo
 }
 
-module.exports = { getOperatorConfirmedEvent }
+// Return the TACo operators confirmed before provided timestamp
+async function getOperatorsConfirmed(timestamp) {
+  if (!timestamp) {
+    timestamp = Math.floor(Date.now() / 1000)
+  }
+
+  const eventIntrfc = new ethers.utils.Interface(eventAbi)
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.POLYGON_RPC_URL
+  )
+
+  // TODO: as stated in ethers.js docs, many backends will discard old events.
+  // Use subgraph instead
+  const rawLogs = await provider.getLogs({
+    address: TACoChildApplicationAdd,
+    topics: [eventTopic],
+    fromBlock: 50223997,
+  })
+
+  // Take the most recent confirmed operator event for each staking provider
+  const filtRawLogs = []
+  rawLogs.forEach((log) => {
+    const lastLog = rawLogs.findLast((elem) => elem.topics[1] === log.topics[1])
+    if (lastLog.transactionHash === log.transactionHash) {
+      filtRawLogs.push(log)
+    }
+  })
+
+  const parsedLogs = filtRawLogs.map((log) => eventIntrfc.parseLog(log))
+
+  const logsTimestamps = {}
+  const promises = filtRawLogs.map((log, logIndex) => {
+    return provider.getBlock(log.blockHash).then((block) => {
+      const stProv = parsedLogs[logIndex].args.stakingProvider
+      logsTimestamps[stProv] = block.timestamp
+    })
+  })
+  await Promise.all(promises)
+
+  // Check if events were confirmed before provided timestamp
+  const filtParsedLogs = parsedLogs.filter(
+    (log) => logsTimestamps[log.args.stakingProvider] <= timestamp
+  )
+
+  const opsConfirmed = {}
+  filtParsedLogs.map((log) => {
+    const stProv = log.args.stakingProvider
+    opsConfirmed[stProv] = {
+      confirmedTimestamp: logsTimestamps[stProv],
+      operator: log.args.operator,
+    }
+  })
+
+  return opsConfirmed
+}
+
+module.exports = { getOperatorConfirmedEvent, getOperatorsConfirmed }


### PR DESCRIPTION
As part of the effort to handle the new Threshold Network TACo application, new functions have been added to get information about new TACo operators.

Also, the rewards calculation script has been updated since the next distribution (Jan 1st 24) will accept both PRE and TACo operators.

More info: #113 