### PR TITLE
Fix legacy Nu stakes miscalculation

### DIFF
--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -80,7 +80,7 @@ async function main() {
 
   // We need the legacy stakes to delete the Keep legacy stakes
   const blockNumber = 18624792 // Block height in which legacy stakes were deac
-  const legacyStakes = await Subgraph.getLegacyStakes(
+  const legacyStakes = await Subgraph.getLegacyKeepStakes(
     graphqlApi,
     blockNumber - 1
   )

--- a/src/scripts/pre-rewards/subgraph.js
+++ b/src/scripts/pre-rewards/subgraph.js
@@ -921,15 +921,13 @@ exports.getLegacyNuRewards = async function (gqlUrl) {
  * @param {number} blockNumber  Block at which legacy stakes were deactivated
  * @returns {Object[]}          Stakes info
  */
-exports.getLegacyStakes = async function (gqlUrl, blockNumber) {
-  const legacyStakersQuery = gql`
-    query legacyStakersQuery($blockNumber: Int) {
+exports.getLegacyKeepStakes = async function (gqlUrl, blockNumber) {
+  const legacyKeepStakersQuery = gql`
+    query legacyKeepStakersQuery($blockNumber: Int) {
       accounts(
         first: 1000
         block: { number: $blockNumber }
-        where: {
-          stakes_: { or: [{ keepInTStake_gt: "0" }, { nuInTStake_gt: "0" }] }
-        }
+        where: { stakes_: { keepInTStake_gt: "0" } }
       ) {
         id
         stakes {
@@ -946,11 +944,11 @@ exports.getLegacyStakes = async function (gqlUrl, blockNumber) {
   const gqlClient = createClient({ url: gqlUrl, maskTypename: true })
 
   const response = await gqlClient
-    .query(legacyStakersQuery, { blockNumber: blockNumber })
+    .query(legacyKeepStakersQuery, { blockNumber: blockNumber })
     .toPromise()
 
   if (response.error) {
-    console.error(`Error in getLegacyStakes: ${response.error.message}`)
+    console.error(`Error in getLegacyKeepStakes: ${response.error.message}`)
     return null
   }
 


### PR DESCRIPTION
Due to a bug in the rewards calculation script, the tBTC part of the rewards for stakes with legacy Nu is not released.

This fixes #120.