### PR TITLE
REDO: Add requirements script for node operator transparency and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In order to run the scripts, it's needed to have a `.env` file that includes:
 
 ```
 ETHERSCAN_TOKEN=<your Etherscan API token>
+POLYGON_RPC_URL=<RPC endpoint to Polygon mainnet>
 ```
 
 ## Claiming rewards

--- a/src/scripts/tbtcv2-rewards/MONITORING.md
+++ b/src/scripts/tbtcv2-rewards/MONITORING.md
@@ -1,0 +1,82 @@
+# Monitoring Threshold Network's tBTCv2 Requirements
+
+`requirements.sh` is a script that pulls your node's record as understood by the official Threshold monitoring systems.  It can be run at any time to check that your node currently meets rewards requirements for the given month.
+
+It is intended to be used for monitoring, specifically for monitoring your node's uptime requirement
+so that you can alert on decreases in uptime that may be sending you on a path to not meeting the uptime requirement.
+
+## Installation
+
+### Node/Yarn
+Ensure that you have a fairly recent version of node and yarn.
+#### Recommended: Node Version Manager
+Install and use [Node Version Manager](https://github.com/nvm-sh/nvm) to obtain your node and yarn dependencies by following the instructions at https://github.com/nvm-sh/nvm#installing-and-updating.
+- After installing nvm, create/edit `.nvm/default-packages` and add `yarn` so that you'll get yarn installed.
+- `nvm install --lts` will install the LTS node/yarn for you
+
+### JQ
+`sudo apt install jq`
+
+### Clone repo and install packages
+- Clone this repo
+- Change directory to the local repo clone root and run `npm install`
+
+## Usage
+
+**Scripts should be run from `src/scripts/tbtcv2-rewards` directory**
+
+> ` cd ./src/scripts/tbtcv-rewards`
+
+### First-time: Obtain Etherscan key
+You'll need an Etherscan API key to run the scripts.  You can get one at https://info.etherscan.com/api-keys/
+
+### First-time: Obtain operator address
+The scripts use your operator address instead of your staking provider address, so you'll need to obtain your operator address using `staker2operator.sh`:
+
+> `./staker2operator.sh --etherscan-token <etherscan token> --staker-address <staking provider address>`
+
+### Running Requirements Script
+> `./requirements.sh --etherscan-token <etherscan token> --operator-address <operator address> --output <filename>`
+
+This is the primary script to use to check if your node is meeting requirements.  It will write the result to the output file, looking something like this:
+```
+[
+    {
+        "requiredUptimePercent": "96",
+        "startTimestamp": 1696118400,
+        "endTimestamp": 1697225528,
+        "startBlock": 18251965,
+        "endBlock": 18343577
+    },
+    {
+        "0x<Staking Provider Address>": {
+            "applications": {
+                "beaconAuthorization": "1116333908567923503741751",
+                "tbtcAuthorization": "1116334357430223004995679"
+            },
+            "instances": {
+                "foo.bar.eu:9601": {
+                    "upTimePercent": 99.67409409358775,
+                    "avgPreParams": 1000,
+                    "version": {
+                        "v2.0.0-m5": 1697225520
+                    }
+                }
+            },
+            "requirements": {
+                "isBeaconAuthorized": true,
+                "isTbtcAuthorized": true,
+                "isUptimeSatisfied": true,
+                "isPreParamsSatisfied": true,
+                "isVersionSatisfied": true
+            }
+        }
+    }
+]
+```
+
+You can run this script on an interval and feed it into your monitoring/alerting system.
+
+## Questions/Comments
+@shoegazer in the #stakers channel of the Threshold discord server
+

--- a/src/scripts/tbtcv2-rewards/package.json
+++ b/src/scripts/tbtcv2-rewards/package.json
@@ -7,19 +7,21 @@
     "beta-operator-rewards"
   ],
   "scripts": {
-    "rewards": "ts-node rewards.ts"
+    "rewards": "ts-node rewards.ts",
+    "requirements": "ts-node requirements.ts",
+    "staker2operator": "ts-node staker2operator.ts"
   },
   "license": "MIT",
   "dependencies": {
-    "@threshold-network/solidity-contracts": "1.2.1",
+    "@keep-network/ecdsa": "2.0.0",
     "@keep-network/random-beacon": "2.0.0",
-    "@keep-network/ecdsa": "2.0.0"
+    "@threshold-network/solidity-contracts": "1.2.1"
   },
   "devDependencies": {
-    "axios": "^0.27.2",
-    "ethers": "^5.7.1",
     "@types/node": "^18.7.23",
+    "axios": "^0.27.2",
     "commander": "^9.4.0",
+    "ethers": "^5.7.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
     "typescript": "^4.8.4"

--- a/src/scripts/tbtcv2-rewards/requirements.sh
+++ b/src/scripts/tbtcv2-rewards/requirements.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -eou pipefail
+
+LOG_START='\n\e[1;36m'           # new line + bold + color
+LOG_END='\n\e[0m'                # new line + reset color
+DONE_START='\n\e[1;32m'          # new line + bold + green
+DONE_END='\n\n\e[0m'             # new line + reset
+LOG_WARNING_START='\n\e\033[33m' # new line + bold + warning color
+LOG_WARNING_END='\n\e\033[0m'    # new line + reset
+
+PROMETHEUS_API_DEFAULT="https://monitoring.threshold.network/prometheus/api/v1"
+PROMETHEUS_JOB_DEFAULT="keep-discovered-nodes"
+REWARDS_JSON_DEFAULT="./rewards.json"
+ETHERSCAN_API_DEFAULT="https://api.etherscan.io"
+NETWORK_DEFAULT="mainnet"
+KEEP_CORE_REPO="https://github.com/keep-network/keep-core"
+REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
+REQUIRED_PRE_PARAMS_DEFAULT=500
+REQUIRED_UPTIME_DEFAULT=96 # percent
+# Default should be 2. In rare cases when we release a hot fix and all 3 tags
+# become eligible in a given interval, then it can be set to 3.
+# Script supports up to 3 tags.
+ELIGIBLE_NUMBER_OF_TAGS=2
+
+help() {
+  echo -e "\nUsage: $0" \
+    "--etherscan-token <etherscan-token>" \
+    "--operator-address <operator-address>" \
+    "--prometheus-api <prometheus-api-address>" \
+    "--prometheus-job <prometheus-job-name>" \
+    "--etherscan-api <etherscan-api-url>" \
+    "--network <network-name>" \
+    "--output <output file>" \
+    "--required-pre-params <required-pre-params>" \
+    "--required-uptime <required-uptime>"
+  echo -e "\nRequired command line arguments:\n"
+  echo -e "\t--etherscan-token: Etherscan API key token"
+  echo -e "\t--operator-address: Operator address to report on." 
+  echo -e "\t--output: Output file for results"
+  echo -e "\nOptional command line arguments:\n"
+  echo -e "\t--prometheus-api: Prometheus API. Default: ${PROMETHEUS_API_DEFAULT}"
+  echo -e "\t--prometheus-job: Prometheus service discovery job name. Default: ${PROMETHEUS_JOB_DEFAULT}"
+  echo -e "\t--etherscan-api: Etherscan API url. Default: ${ETHERSCAN_API_DEFAULT}"
+  echo -e "\t--network: Network name. Default: ${NETWORK_DEFAULT}"
+  echo -e "\t--required-pre-params: Required pre-params. Default: ${REQUIRED_PRE_PARAMS_DEFAULT}"
+  echo -e "\t--required-uptime: Required client uptime. Default: ${REQUIRED_UPTIME_DEFAULT}"
+  echo -e ""
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  "--etherscan-token") set -- "$@" "-t" ;;
+  "--etherscan-api") set -- "$@" "-r" ;;
+  "--prometheus-api") set -- "$@" "-a" ;;
+  "--prometheus-job") set -- "$@" "-p" ;;
+  "--network") set -- "$@" "-n" ;;
+  "--output") set -- "$@" "-d" ;;
+  "--required-pre-params") set -- "$@" "-s" ;;
+  "--required-uptime") set -- "$@" "-m" ;;
+  "--operator-address") set -- "$@" "-x" ;;
+  "--help") set -- "$@" "-h" ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "t:r:a:p:n:d:s:m:x:h" opt; do
+  case "$opt" in
+  t) etherscan_token="$OPTARG" ;;
+  r) etherscan_api="$OPTARG" ;;
+  a) prometheus_api="$OPTARG" ;;
+  p) prometheus_job="$OPTARG" ;;
+  n) network="$OPTARG" ;;
+  d) output_file="$OPTARG" ;;
+  s) required_pre_params="$OPTARG" ;;
+  m) required_uptime="$OPTARG" ;;
+  x) operator_address="$OPTARG" ;;
+  h) help ;;
+  ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+ETHERSCAN_TOKEN=${etherscan_token:-""}
+# Can't use "now" cuz we won't find an ending block
+REWARDS_END_DATE=$(date --date='15 minutes ago' +%s)
+REWARDS_START_DATE=$(date -d @${REWARDS_END_DATE} +"%Y-%m-%d")
+[[ "${REWARDS_START_DATE}" =~ (....-..-) ]]
+REWARDS_START_DATE=$(date -d ${BASH_REMATCH[0]}01 +%s)
+PROMETHEUS_API=${prometheus_api:-${PROMETHEUS_API_DEFAULT}}
+PROMETHEUS_JOB=${prometheus_job:-${PROMETHEUS_JOB_DEFAULT}}
+REWARDS_JSON=${rewards_json:-${REWARDS_JSON_DEFAULT}}
+ETHERSCAN_API=${etherscan_api:-${ETHERSCAN_API_DEFAULT}}
+NETWORK=${network:-${NETWORK_DEFAULT}}
+REWARDS_DETAILS_PATH=${rewards_details_path:-${REWARDS_DETAILS_PATH_DEFAULT}}
+REQUIRED_PRE_PARAMS=${required_pre_params:-${REQUIRED_PRE_PARAMS_DEFAULT}}
+REQUIRED_UPTIME=${required_uptime:-${REQUIRED_UPTIME_DEFAULT}}
+
+if [ "$REWARDS_START_DATE" == "" ]; then
+  printf "${LOG_WARNING_START}Rewards start date must be provided.${LOG_WARNING_END}"
+  help
+fi
+
+if [ "$REWARDS_END_DATE" == "" ]; then
+  printf "${LOG_WARNING_START}Rewards end date must be provided.${LOG_WARNING_END}"
+  help
+fi
+
+if [ "$ETHERSCAN_TOKEN" == "" ]; then
+  printf "${LOG_WARNING_START}Etherscan API key token must be provided.${LOG_WARNING_END}"
+  help
+fi
+
+# TBTCv2 rewards must be calculated since Oct 1st 2022
+if [ "$REWARDS_START_DATE" -lt "1664582400" ]; then
+  REWARDS_START_DATE=1664582400
+fi
+
+startBlockApiCall="${ETHERSCAN_API}/api?\
+module=block&\
+action=getblocknobytime&\
+timestamp=$REWARDS_START_DATE&\
+closest=after&\
+apikey=${ETHERSCAN_TOKEN}"
+
+endBlockApiCall="${ETHERSCAN_API}/api?\
+module=block&\
+action=getblocknobytime&\
+timestamp=$REWARDS_END_DATE&\
+closest=after&\
+apikey=${ETHERSCAN_TOKEN}"
+
+startRewardsBlock=$(curl -s $startBlockApiCall | jq '.result|tonumber')
+endRewardsBlock=$(curl -s $endBlockApiCall | jq '.result|tonumber')
+
+printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
+yarn install
+
+printf "${LOG_START}Retrieving client release tags...${LOG_END}"
+# Create a new git remote to fetch the release tags
+git remote remove keep-core-repo 2>/dev/null || true
+git remote add keep-core-repo ${KEEP_CORE_REPO}
+git fetch --tags --prune --quiet keep-core-repo
+allTags=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]'))
+printf "Found ${allTags[*]} tags"
+latestTag=${allTags[0]}
+latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 1))
+latestTagTimestamp="${latestTag}_$latestTimestamp"
+
+# There are at least 2 tags available at this point of time
+secondToLatestTag=${allTags[1]}
+secondToLatestTagTimestamp="${secondToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 2 | tail -1)"
+
+tagsInRewardInterval=()
+tagsInRewardInterval+=($latestTagTimestamp)
+tagsInRewardInterval+=($secondToLatestTagTimestamp)
+
+if [ "$ELIGIBLE_NUMBER_OF_TAGS" -eq "3" ]; then
+  thirdToLatestTag=${allTags[2]}
+  thirdToLatestTagTimestamp="${thirdToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*.*-m[0-9]' --format '%(creatordate:unix)' | head -n 3 | tail -1)"
+  tagsInRewardInterval+=($thirdToLatestTagTimestamp)
+fi
+
+# Converting array to string so we can pass to the rewards-requirements.ts
+printf -v tags '%s|' "${tagsInRewardInterval[@]}"
+tagsTrimmed="${tags%?}" # remove "|" at the end
+
+# Removing created remote
+git remote remove keep-core-repo
+
+# Run script
+printf "${LOG_START}Fetching peers data...${LOG_END}"
+
+ETHERSCAN_TOKEN=${ETHERSCAN_TOKEN} yarn requirements \
+  --api ${PROMETHEUS_API} \
+  --job ${PROMETHEUS_JOB} \
+  --start-timestamp $REWARDS_START_DATE \
+  --end-timestamp $REWARDS_END_DATE \
+  --start-block $startRewardsBlock \
+  --end-block $endRewardsBlock \
+  --releases $tagsTrimmed \
+  --network ${NETWORK} \
+  --output-file ${output_file} \
+  --required-pre-params ${REQUIRED_PRE_PARAMS} \
+  --required-uptime ${REQUIRED_UPTIME} \
+  --operator-address $operator_address
+
+printf "${DONE_START}Complete!${DONE_END}"

--- a/src/scripts/tbtcv2-rewards/requirements.ts
+++ b/src/scripts/tbtcv2-rewards/requirements.ts
@@ -15,7 +15,6 @@ import {
   abi as TokenStakingABI,
   address as TokenStakingAddress,
 } from "@threshold-network/solidity-contracts/artifacts/TokenStaking.json"
-import axios from "axios"
 import {
   BEACON_AUTHORIZATION,
   TBTC_AUTHORIZATION,
@@ -24,12 +23,11 @@ import {
   IS_UP_TIME_SATISFIED,
   IS_PRE_PARAMS_SATISFIED,
   IS_VERSION_SATISFIED,
-  ALLOWED_UPGRADE_DELAY,
   PRECISION,
   OPERATORS_SEARCH_QUERY_STEP,
-  QUERY_RESOLUTION,
-  HUNDRED,
 } from "./rewards-constants"
+import { InstanceParams } from "./types"
+import { Utils } from "./utils"
 
 program
   .version("0.0.1")
@@ -85,11 +83,15 @@ const prometheusAPIQuery = `${prometheusAPI}/query`
 // rewards interval dates.
 const offset = Math.floor(Date.now() / 1000) - endRewardsTimestamp
 
-type InstanceParams = {
-  upTimePercent: number
-  avgPreParams: number
-  version: any
-}
+const utils = new Utils(
+  prometheusAPI,
+  prometheusAPIQuery,
+  prometheusJob,
+  offset,
+  endRewardsTimestamp,
+  requiredUptime,
+  requiredPreParams
+)
 
 export async function calculateRequirements() {
   if (Date.now() / 1000 < endRewardsTimestamp) {
@@ -115,7 +117,7 @@ export async function calculateRequirements() {
   }
 
   const bootstrapData = (
-    await queryPrometheus(queryBootstrapData, paramsBootstrapData)
+    await utils.queryPrometheus(queryBootstrapData, paramsBootstrapData)
   ).data.result
 
   const operatorsData = new Array()
@@ -287,7 +289,7 @@ export async function calculateRequirements() {
       )
     }
 
-    const beaconAuthorization = await getAuthorization(
+    const beaconAuthorization = await utils.getAuthorization(
       randomBeacon,
       beaconIntervalEvents,
       beaconPostIntervalEvents,
@@ -314,7 +316,7 @@ export async function calculateRequirements() {
       )
     }
 
-    const tbtcAuthorization = await getAuthorization(
+    const tbtcAuthorization = await utils.getAuthorization(
       walletRegistry,
       tbtcIntervalEvents,
       tbtcPostIntervalEvents,
@@ -330,10 +332,14 @@ export async function calculateRequirements() {
     /// Off-chain client reqs
 
     // Populate instances for a given operator.
-    await instancesForOperator(operatorAddress, rewardsInterval, instancesData)
+    await utils.instancesForOperator(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
 
     /// Uptime requirement
-    let { uptimeCoefficient, isUptimeSatisfied } = await checkUptime(
+    let { uptimeCoefficient, isUptimeSatisfied } = await utils.checkUptime(
       operatorAddress,
       rewardsInterval,
       instancesData
@@ -344,7 +350,7 @@ export async function calculateRequirements() {
     requirements.set(IS_UP_TIME_SATISFIED, isUptimeSatisfied)
 
     /// Pre-params requirement
-    const isPrePramsSatisfied = await checkPreParams(
+    const isPrePramsSatisfied = await utils.checkPreParams(
       operatorAddress,
       rewardsInterval,
       instancesData
@@ -352,95 +358,21 @@ export async function calculateRequirements() {
 
     requirements.set(IS_PRE_PARAMS_SATISFIED, isPrePramsSatisfied)
 
-    // keep-core client already has at least 2 released versions
-    const latestClient = clientReleases[0].split("_")
-    const latestClientTag = latestClient[0]
-    const latestClientTagTimestamp = Number(latestClient[1])
-    const secondToLatestClient = clientReleases[1].split("_")
-    const secondToLatestClientTag = secondToLatestClient[0]
-
-    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
-
-    if (clientReleases.length == 3) {
-      const thirdToLatestClient = clientReleases[2].split("_")
-      const thirdToLatestClientTag = thirdToLatestClient[0]
-      eligibleClientTags.push(thirdToLatestClientTag)
-    }
-
-    const instances = await processBuildVersions(
-      operatorAddress,
-      rewardsInterval,
-      instancesData
+    requirements.set(
+      IS_VERSION_SATISFIED,
+      await utils.isVersionSatisfied(
+        operatorAddress,
+        rewardsInterval,
+        startRewardsTimestamp,
+        endRewardsTimestamp,
+        clientReleases,
+        instancesData
+      )
     )
-
-    const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
-    requirements.set(IS_VERSION_SATISFIED, true)
-    if (upgradeCutoffDate < startRewardsTimestamp) {
-      // E.g. Feb interval
-      // ---older eligible tags---|----------latest tag only--------------|
-      // ---|---------------------|---------|-----------------------------|--->
-      // latest tag             cutoff     Feb1                         Feb28
-
-      // All the instances must run on the latest version during the rewards
-      // interval in Feb.
-      for (let i = 0; i < instances.length; i++) {
-        if (instances[i].buildVersion != latestClientTag) {
-          requirements.set(IS_VERSION_SATISFIED, false)
-        }
-      }
-    } else if (upgradeCutoffDate < endRewardsTimestamp) {
-      // E.g. Feb interval
-      // -----older eligible tags-----|----latest tag only----|
-      // ----|---------|--------------|-----------------------|--->
-      // latest tag   Feb1          cutoff                   Feb28
-
-      // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
-      // must run on the latest version
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (
-          instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
-          !instances[i].buildVersion.includes(latestClientTag)
-        ) {
-          // After the cutoff day a node operator still run an instance with an
-          // older version. No rewards.
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check further since at least one instance run on the
-          // older version after the cutoff day.
-          break
-        } else {
-          // It might happen that a node operator stopped an instance before the
-          // upgrade cutoff date that happens to be right before the interval
-          // end date. However, it might still be eligible for rewards because
-          // of the uptime requirement.
-          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
-            requirements.set(IS_VERSION_SATISFIED, false)
-            // No need to check other instances because at least one instance run
-            // on the older version than 2 latest allowed.
-            break
-          }
-        }
-      }
-    } else {
-      // E.g. Feb interval
-      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
-      // --|-----------------------|---------------|------------|-->
-      //  Feb1                latest tag         Feb28        cutoff
-
-      // For simplicity purposes all the instances can run on any of the eligible
-      // versions.
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check other instances because at least one instance run
-          // on a version that is no longer eligible in this rewards interval.
-          break
-        }
-      }
-    }
 
     operatorData[stakingProvider] = {
       applications: Object.fromEntries(authorizations),
-      instances: convertToObject(instancesData),
+      instances: utils.convertToObject(instancesData),
       requirements: Object.fromEntries(requirements),
     }
 
@@ -458,313 +390,6 @@ export async function calculateRequirements() {
   })
 
   fs.writeFileSync(outputFile, JSON.stringify(operatorsData, null, 4))
-}
-
-async function getAuthorization(
-  application: Contract,
-  intervalEvents: any[],
-  postIntervalEvents: any[],
-  stakingProvider: string,
-  startRewardsBlock: number,
-  endRewardsBlock: number,
-  currentBlockNumber: number
-) {
-  if (intervalEvents.length > 0) {
-    return authorizationForRewardsInterval(
-      intervalEvents,
-      startRewardsBlock,
-      endRewardsBlock
-    )
-  }
-
-  // Events that were emitted between the [end:firstEventDate|currentDate] dates.
-  // This is used to fetch the authorization that was set during the rewards
-  // interval.
-  return await authorizationPostRewardsInterval(
-    postIntervalEvents,
-    application,
-    stakingProvider,
-    currentBlockNumber
-  )
-}
-
-// Calculates the weighted authorization for rewards interval based on events.
-// The general idea of weighted rewards calculation describes the following example.
-// Please note that this example operates on dates for simplicity purposes,
-// however the actual calculation is based on block numbers.
-// Ex.
-// events:         ^     ^      *    *   ^
-// timeline:  -|---|-----|------|----|---|--------|-->
-//         Sep 0   3     8      14  18   22       30
-// where: '^' denotes increase in authorization
-//        '*' denotes decrease in authorization
-//         0 -> Sep 1 at 00:00:00
-// event authorizations:
-//  Sep 0 - 3 from 100k to 110k
-//  Sep 3 - 8 from 110k to 135k
-//  Sep 8 - 14 from 135k to 120k
-//  Sep 14 - 18 from 120k to 100k
-//  Sep 18 - 30 constant 100k (last sub-interval)
-// Weighted authorization = (3-0)/30*100 + (8-3)/30*110 + (14-8)/30*135
-//                        + (18-14)/30*120 + (30-18)/30*100
-function authorizationForRewardsInterval(
-  intervalEvents: any[],
-  startRewardsBlock: number,
-  endRewardsBlock: number
-) {
-  let authorization = BigNumber.from("0")
-  const deltaRewardsBlock = endRewardsBlock - startRewardsBlock
-  // ascending order
-  intervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
-
-  let tmpBlock = startRewardsBlock // prev tmp block
-
-  let index = 0
-
-  for (let i = index; i < intervalEvents.length; i++) {
-    const eventBlock = intervalEvents[i].blockNumber
-    const coefficient = Math.floor(
-      ((eventBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
-    )
-    authorization = authorization.add(
-      intervalEvents[i].args.fromAmount.mul(coefficient)
-    )
-    tmpBlock = eventBlock
-  }
-
-  // calculating authorization for the last sub-interval
-  const coefficient = Math.floor(
-    ((endRewardsBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
-  )
-  authorization = authorization.add(
-    intervalEvents[intervalEvents.length - 1].args.toAmount.mul(coefficient)
-  )
-
-  return authorization.div(PRECISION)
-}
-
-// Get the authorization from the first event that occurred after the rewards
-// interval. If no events were emitted, then get the authorization from the current
-// block.
-async function authorizationPostRewardsInterval(
-  postIntervalEvents: any[],
-  application: Contract,
-  stakingProvider: string,
-  currentBlockNumber: number
-) {
-  // Sort events in ascending order
-  postIntervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
-
-  if (
-    postIntervalEvents.length > 0 &&
-    postIntervalEvents[0].blockNumber < currentBlockNumber
-  ) {
-    // There are events (increase or decrease) present after the rewards interval
-    // and before the current block. Take the "fromAmount", because it was the
-    // same as for the rewards interval dates.
-    return postIntervalEvents[0].args.fromAmount
-  }
-
-  // There were no authorization events after the rewards interval and before
-  // the current block.
-  // Current authorization is the same as the authorization at the end of the
-  // rewards interval.
-  const authorization = await application.eligibleStake(stakingProvider)
-  return authorization
-}
-
-async function instancesForOperator(
-  operatorAddress: any,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  // Resolution is defaulted to Prometheus settings.
-  const instancesDataByOperatorParams = {
-    query: `present_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-                [${rewardsInterval}s] offset ${offset}s)`,
-  }
-  const instancesDataByOperator = (
-    await queryPrometheus(prometheusAPIQuery, instancesDataByOperatorParams)
-  ).data.result
-
-  instancesDataByOperator.forEach(
-    (element: { metric: { instance: string } }) => {
-      const instanceData = {}
-      instancesData.set(element.metric.instance, instanceData as InstanceParams)
-    }
-  )
-}
-
-// Peer uptime requirement. The total uptime for all the instances for a given
-// operator has to be greater than 96% to receive the rewards.
-async function checkUptime(
-  operatorAddress: string,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  const paramsOperatorUptime = {
-    query: `up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-            [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
-  }
-
-  const instances = (
-    await queryPrometheus(prometheusAPIQuery, paramsOperatorUptime)
-  ).data.result
-
-  // First registered 'up' metric in a given interval <start:end> for a given
-  // operator. Start evaluating uptime from this point.
-  const firstRegisteredUptime = instances.reduce(
-    (currentMin: number, instance: any) =>
-      Math.min(instance.values[0][0], currentMin),
-    Number.MAX_VALUE
-  )
-
-  let uptimeSearchRange = endRewardsTimestamp - firstRegisteredUptime
-
-  const paramsSumUptimes = {
-    query: `sum_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-            [${uptimeSearchRange}s:${QUERY_RESOLUTION}s] offset ${offset}s)
-            * ${QUERY_RESOLUTION} / ${uptimeSearchRange}`,
-  }
-
-  const uptimesByInstance = (
-    await queryPrometheus(prometheusAPIQuery, paramsSumUptimes)
-  ).data.result
-
-  let sumUptime = 0
-  for (let i = 0; i < uptimesByInstance.length; i++) {
-    const instance = uptimesByInstance[i]
-    const uptime = instance.value[1] * HUNDRED
-    const dataInstance = instancesData.get(instance.metric.instance)
-    if (dataInstance !== undefined) {
-      dataInstance.upTimePercent = uptime
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-
-    sumUptime += uptime
-  }
-
-  const isUptimeSatisfied = sumUptime >= requiredUptime
-
-  const uptimeCoefficient = isUptimeSatisfied
-    ? uptimeSearchRange / rewardsInterval
-    : 0
-  return { uptimeCoefficient, isUptimeSatisfied }
-}
-
-async function checkPreParams(
-  operatorAddress: string,
-  rewardsInterval: number,
-  dataInstances: Map<string, InstanceParams>
-) {
-  // Avg of pre-params across all the instances for a given operator in the rewards
-  // interval dates. Resolution is defaulted to Prometheus settings.
-  const paramsPreParams = {
-    query: `avg_over_time(tbtc_pre_params_count{chain_address="${operatorAddress}", job="${prometheusJob}"}
-              [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s)`,
-  }
-
-  const preParamsAvgByInstance = (
-    await queryPrometheus(prometheusAPIQuery, paramsPreParams)
-  ).data.result
-
-  let sumPreParams = 0
-  for (let i = 0; i < preParamsAvgByInstance.length; i++) {
-    const instance = preParamsAvgByInstance[i]
-    const preParams = parseInt(instance.value[1]) // [timestamp, value]
-    const dataInstance = dataInstances.get(instance.metric.instance)
-    if (dataInstance !== undefined) {
-      dataInstance.avgPreParams = preParams
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-
-    sumPreParams += preParams
-  }
-
-  const preParamsAvg = sumPreParams / preParamsAvgByInstance.length
-  return preParamsAvg >= requiredPreParams
-}
-
-// Query Prometheus and fetch instances that run on either of two latest client
-// versions and mark their first and last registered timestamp.
-async function processBuildVersions(
-  operatorAddress: string,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  const buildVersionInstancesParams = {
-    query: `client_info{chain_address="${operatorAddress}", job="${prometheusJob}"}[${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
-  }
-  // Get instances data for a given rewards interval
-  const queryBuildVersionInstances = (
-    await queryPrometheus(prometheusAPIQuery, buildVersionInstancesParams)
-  ).data.result
-
-  let instances = []
-  const lastRegisteredVersion = new Map<string, string>() // version -> last registered timestamp
-
-  // Determine client's build version for it all it's instances
-  for (let i = 0; i < queryBuildVersionInstances.length; i++) {
-    const instance = queryBuildVersionInstances[i]
-
-    const instanceTimestampsVersionInfo = {
-      // First timestamp registered by Prometheus for a given instance
-      firstRegisteredTimestamp: instance.values[0][0],
-      // Last timestamp registered by Prometheus for a given instance
-      lastRegisteredTimestamp: instance.values[instance.values.length - 1][0],
-      buildVersion: instance.metric.version,
-    }
-
-    instances.push(instanceTimestampsVersionInfo)
-
-    const dataInstance = instancesData.get(instance.metric.instance)
-    lastRegisteredVersion.set(
-      instanceTimestampsVersionInfo.buildVersion,
-      instanceTimestampsVersionInfo.lastRegisteredTimestamp
-    )
-    if (dataInstance !== undefined) {
-      dataInstance.version = Object.fromEntries(lastRegisteredVersion)
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-  }
-
-  // Sort instances in ascending order by first registration timestamp
-  instances.sort((a, b) =>
-    a.firstRegisteredTimestamp > b.firstRegisteredTimestamp ? 1 : -1
-  )
-
-  return instances
-}
-
-function convertToObject(map: Map<string, InstanceParams>) {
-  let obj: { [k: string]: any } = {}
-  map.forEach((value: InstanceParams, key: string) => {
-    obj[key] = value
-  })
-
-  return obj
-}
-
-async function queryPrometheus(url: string, params: any): Promise<any> {
-  try {
-    const { data } = await axios.get(url, { params: params })
-
-    return data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      console.log("error message: ", error.message)
-      return error.message
-    } else {
-      console.log("unexpected error: ", error)
-      return "An unexpected error occurred"
-    }
-  }
 }
 
 // Special case: Dec 1st 23 distribution

--- a/src/scripts/tbtcv2-rewards/requirements.ts
+++ b/src/scripts/tbtcv2-rewards/requirements.ts
@@ -1,0 +1,803 @@
+import { BigNumber } from "@ethersproject/bignumber"
+import { Contract } from "ethers"
+import { program } from "commander"
+import * as fs from "fs"
+import { ethers } from "ethers"
+import {
+  abi as RandomBeaconABI,
+  address as RandomBeaconAddress,
+} from "@keep-network/random-beacon/artifacts/RandomBeacon.json"
+import {
+  abi as WalletRegistryABI,
+  address as WalletRegistryAddress,
+} from "@keep-network/ecdsa/artifacts/WalletRegistry.json"
+import {
+  abi as TokenStakingABI,
+  address as TokenStakingAddress,
+} from "@threshold-network/solidity-contracts/artifacts/TokenStaking.json"
+import axios from "axios"
+import {
+  BEACON_AUTHORIZATION,
+  TBTC_AUTHORIZATION,
+  IS_BEACON_AUTHORIZED,
+  IS_TBTC_AUTHORIZED,
+  IS_UP_TIME_SATISFIED,
+  IS_PRE_PARAMS_SATISFIED,
+  IS_VERSION_SATISFIED,
+  ALLOWED_UPGRADE_DELAY,
+  PRECISION,
+  OPERATORS_SEARCH_QUERY_STEP,
+  QUERY_RESOLUTION,
+  HUNDRED,
+} from "./rewards-constants"
+
+program
+  .version("0.0.1")
+  .requiredOption(
+    "-s, --start-timestamp <timestamp>",
+    "starting time for rewards calculation"
+  )
+  .requiredOption(
+    "-e, --end-timestamp <timestamp>",
+    "ending time for rewards calculation"
+  )
+  .requiredOption(
+    "-b, --start-block <timestamp>",
+    "start block for rewards calculation"
+  )
+  .requiredOption(
+    "-z, --end-block <timestamp>",
+    "end block for rewards calculation"
+  )
+  .requiredOption("-a, --api <prometheus api>", "prometheus API")
+  .requiredOption("-j, --job <prometheus job>", "prometheus job")
+  .requiredOption(
+    "-r, --releases <client releases in a rewards interval>",
+    "client releases in a rewards interval"
+  )
+  .requiredOption("-n, --network <name>", "network name")
+  .requiredOption(
+    "-x, --operator-address <address>",
+    "Only report on staker address"
+  )
+  .requiredOption("-d, --output-file <file>", "output JSON details path")
+  .requiredOption("-q, --required-pre-params <number>", "required pre params")
+  .requiredOption("-m, --required-uptime <percent>", "required uptime")
+  .parse(process.argv)
+
+// Parse the program options
+const options = program.opts()
+const prometheusJob = options.job
+const prometheusAPI = options.api
+const clientReleases = options.releases.split("|") // sorted from latest to oldest
+const startRewardsTimestamp = parseInt(options.startTimestamp)
+const endRewardsTimestamp = parseInt(options.endTimestamp)
+const startRewardsBlock = parseInt(options.startBlock)
+const endRewardsBlock = parseInt(options.endBlock)
+const operatorAddress = options.operatorAddress
+const outputFile = options.outputFile
+const network = options.network
+const requiredPreParams = options.requiredPreParams
+const requiredUptime = options.requiredUptime // percent
+
+const prometheusAPIQuery = `${prometheusAPI}/query`
+// Go back in time relevant to the current date to get data for the exact
+// rewards interval dates.
+const offset = Math.floor(Date.now() / 1000) - endRewardsTimestamp
+
+type InstanceParams = {
+  upTimePercent: number
+  avgPreParams: number
+  version: any
+}
+
+export async function calculateRewards() {
+  if (Date.now() / 1000 < endRewardsTimestamp) {
+    console.log("End time interval must be in the past")
+    return "End time interval must be in the past"
+  }
+
+  const provider = new ethers.providers.EtherscanProvider(
+    network,
+    process.env.ETHERSCAN_TOKEN
+  )
+
+  const rewardsInterval = endRewardsTimestamp - startRewardsTimestamp
+  const currentBlockNumber = await provider.getBlockNumber()
+
+  // Query for bootstrap data that has peer instances grouped by operators
+  const queryBootstrapData = `${prometheusAPI}/query_range`
+  const paramsBootstrapData = {
+    query: `sum by(chain_address)({job='${prometheusJob}'})`,
+    start: startRewardsTimestamp,
+    end: endRewardsTimestamp,
+    step: OPERATORS_SEARCH_QUERY_STEP,
+  }
+
+  const bootstrapData = (
+    await queryPrometheus(queryBootstrapData, paramsBootstrapData)
+  ).data.result
+
+  const operatorsData = new Array()
+
+  const randomBeacon = new Contract(
+    RandomBeaconAddress,
+    JSON.stringify(RandomBeaconABI),
+    provider
+  )
+
+  const tokenStaking = new Contract(
+    TokenStakingAddress,
+    JSON.stringify(TokenStakingABI),
+    provider
+  )
+
+  const walletRegistry = new Contract(
+    WalletRegistryAddress,
+    JSON.stringify(WalletRegistryABI),
+    provider
+  )
+
+  console.log("Fetching AuthorizationIncreased events in rewards interval...")
+  const intervalAuthorizationIncreasedEvents = await tokenStaking.queryFilter(
+    "AuthorizationIncreased",
+    startRewardsBlock,
+    endRewardsBlock
+  )
+
+  console.log("Fetching AuthorizationDecreased events in rewards interval...")
+  let intervalAuthorizationDecreasedEvents = await tokenStaking.queryFilter(
+    "AuthorizationDecreaseApproved",
+    startRewardsBlock,
+    endRewardsBlock
+  )
+
+  console.log(
+    "Fetching AuthorizationIncreased events after rewards interval..."
+  )
+  const postIntervalAuthorizationIncreasedEvents =
+    await tokenStaking.queryFilter(
+      "AuthorizationIncreased",
+      endRewardsBlock,
+      currentBlockNumber
+    )
+
+  console.log(
+    "Fetching AuthorizationDecreasedApproved events after rewards interval..."
+  )
+  let postIntervalAuthorizationDecreasedApprovedEvents =
+    await tokenStaking.queryFilter(
+      "AuthorizationDecreaseApproved",
+      endRewardsBlock,
+      currentBlockNumber
+    )
+
+  console.log(
+    "Fetching AuthorizationDecreasedRequested events after rewards interval..."
+  )
+  let postIntervalAuthorizationDecreasedRequestedEvents =
+    await tokenStaking.queryFilter(
+      "AuthorizationDecreaseRequested",
+      endRewardsBlock,
+      currentBlockNumber
+    )
+
+  // Special case: legacy stakes
+  // const legacyEvents = await getLegacyEvents(provider)
+
+  // For Dec 1st distribution, legacy stakes will not receive rewards.
+  // The corresponding rewards will be received in following distributions.
+  const legacyEvents: ethers.Event[] = []
+
+  const intervalLegacyEvents = legacyEvents.filter(
+    (event) =>
+      event.blockNumber >= startRewardsBlock &&
+      event.blockNumber < endRewardsBlock
+  )
+  const postLegacyEvents = legacyEvents.filter(
+    (event) => event.blockNumber > endRewardsBlock - 1
+  )
+
+  intervalAuthorizationDecreasedEvents =
+    intervalAuthorizationDecreasedEvents.concat(intervalLegacyEvents)
+
+  const postIntervalAuthorizationDecreasedEvents =
+    postIntervalAuthorizationDecreasedApprovedEvents
+      .concat(postIntervalAuthorizationDecreasedRequestedEvents)
+      .concat(postLegacyEvents)
+
+  /// filter out operators we don't care about
+  const operators = bootstrapData.filter(
+    (bootstrapEntry: any) =>
+      bootstrapEntry.metric.chain_address.toLowerCase() ===
+      operatorAddress.toLowerCase()
+  )
+
+  if (!operators.length) {
+    console.log(
+      `No operator found for ${operatorAddress} in list of operator addresses: `
+    )
+    bootstrapData.forEach((o: any) => console.log(o.metric.chain_address))
+  }
+
+  for (let i = 0; i < operators.length; i++) {
+    const operatorAddress = operators[i].metric.chain_address
+    let authorizations = new Map<string, BigNumber>() // application: value
+    let requirements = new Map<string, boolean>() // factor: true | false
+    let instancesData = new Map<string, InstanceParams>()
+    let operatorData: any = {}
+
+    // Staking provider should be the same for Beacon and TBTC apps
+    const stakingProvider = await randomBeacon.operatorToStakingProvider(
+      operatorAddress
+    )
+    const stakingProviderAddressForTbtc =
+      await walletRegistry.operatorToStakingProvider(operatorAddress)
+
+    if (stakingProvider !== stakingProviderAddressForTbtc) {
+      console.log(
+        `Staking providers for Beacon ${stakingProvider} and TBTC ${stakingProviderAddressForTbtc} must match. ` +
+          `No Rewards were calculated for operator ${operatorAddress}`
+      )
+      continue
+    }
+
+    if (stakingProvider === ethers.constants.AddressZero) {
+      console.log(
+        "Staking provider cannot be zero address. " +
+          `No Rewards were calculated for operator ${operatorAddress}`
+      )
+      continue
+    }
+
+    // Events that were emitted between the [start:end] rewards dates for a given
+    // stakingProvider.
+    let intervalEvents = intervalAuthorizationIncreasedEvents.concat(
+      intervalAuthorizationDecreasedEvents
+    )
+    if (intervalEvents.length > 0) {
+      intervalEvents = intervalEvents.filter(
+        (event) => event.args!.stakingProvider === stakingProvider
+      )
+    }
+
+    // Events that were emitted between the [end:now] dates for a given
+    // stakingProvider.
+    let postIntervalEvents = postIntervalAuthorizationIncreasedEvents.concat(
+      postIntervalAuthorizationDecreasedEvents
+    )
+    if (postIntervalEvents.length > 0) {
+      postIntervalEvents = postIntervalEvents.filter(
+        (event) => event.args!.stakingProvider === stakingProvider
+      )
+    }
+
+    /// Random Beacon application authorization requirement
+    let beaconIntervalEvents = new Array()
+    if (intervalEvents.length > 0) {
+      beaconIntervalEvents = intervalEvents.filter(
+        (obj) => obj.args!.application == randomBeacon.address
+      )
+    }
+
+    let beaconPostIntervalEvents = new Array()
+    if (postIntervalEvents.length > 0) {
+      beaconPostIntervalEvents = postIntervalEvents.filter(
+        (obj) => obj.args!.application == randomBeacon.address
+      )
+    }
+
+    const beaconAuthorization = await getAuthorization(
+      randomBeacon,
+      beaconIntervalEvents,
+      beaconPostIntervalEvents,
+      stakingProvider,
+      startRewardsBlock,
+      endRewardsBlock,
+      currentBlockNumber
+    )
+    authorizations.set(BEACON_AUTHORIZATION, beaconAuthorization.toString())
+    requirements.set(IS_BEACON_AUTHORIZED, !beaconAuthorization.isZero())
+
+    /// tBTC application authorized requirement
+    let tbtcIntervalEvents = new Array()
+    if (intervalEvents.length > 0) {
+      tbtcIntervalEvents = intervalEvents.filter(
+        (obj) => obj.args!.application == walletRegistry.address
+      )
+    }
+
+    let tbtcPostIntervalEvents = new Array()
+    if (postIntervalEvents.length > 0) {
+      tbtcPostIntervalEvents = postIntervalEvents.filter(
+        (obj) => obj.args!.application == walletRegistry.address
+      )
+    }
+
+    const tbtcAuthorization = await getAuthorization(
+      walletRegistry,
+      tbtcIntervalEvents,
+      tbtcPostIntervalEvents,
+      stakingProvider,
+      startRewardsBlock,
+      endRewardsBlock,
+      currentBlockNumber
+    )
+
+    authorizations.set(TBTC_AUTHORIZATION, tbtcAuthorization.toString())
+    requirements.set(IS_TBTC_AUTHORIZED, !tbtcAuthorization.isZero())
+
+    /// Off-chain client reqs
+
+    // Populate instances for a given operator.
+    await instancesForOperator(operatorAddress, rewardsInterval, instancesData)
+
+    /// Uptime requirement
+    let { uptimeCoefficient, isUptimeSatisfied } = await checkUptime(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
+    // BigNumbers cannot operate on floats. Coefficient needs to be multiplied
+    // by PRECISION
+    uptimeCoefficient = Math.floor(uptimeCoefficient * PRECISION)
+    requirements.set(IS_UP_TIME_SATISFIED, isUptimeSatisfied)
+
+    /// Pre-params requirement
+    const isPrePramsSatisfied = await checkPreParams(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
+
+    requirements.set(IS_PRE_PARAMS_SATISFIED, isPrePramsSatisfied)
+
+    // keep-core client already has at least 2 released versions
+    const latestClient = clientReleases[0].split("_")
+    const latestClientTag = latestClient[0]
+    const latestClientTagTimestamp = Number(latestClient[1])
+    const secondToLatestClient = clientReleases[1].split("_")
+    const secondToLatestClientTag = secondToLatestClient[0]
+
+    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
+
+    if (clientReleases.length == 3) {
+      const thirdToLatestClient = clientReleases[2].split("_")
+      const thirdToLatestClientTag = thirdToLatestClient[0]
+      eligibleClientTags.push(thirdToLatestClientTag)
+    }
+
+    const instances = await processBuildVersions(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
+
+    const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
+    requirements.set(IS_VERSION_SATISFIED, true)
+    if (upgradeCutoffDate < startRewardsTimestamp) {
+      // E.g. Feb interval
+      // ---older eligible tags---|----------latest tag only--------------|
+      // ---|---------------------|---------|-----------------------------|--->
+      // latest tag             cutoff     Feb1                         Feb28
+
+      // All the instances must run on the latest version during the rewards
+      // interval in Feb.
+      for (let i = 0; i < instances.length; i++) {
+        if (instances[i].buildVersion != latestClientTag) {
+          requirements.set(IS_VERSION_SATISFIED, false)
+        }
+      }
+    } else if (upgradeCutoffDate < endRewardsTimestamp) {
+      // E.g. Feb interval
+      // -----older eligible tags-----|----latest tag only----|
+      // ----|---------|--------------|-----------------------|--->
+      // latest tag   Feb1          cutoff                   Feb28
+
+      // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
+      // must run on the latest version
+      for (let i = instances.length - 1; i >= 0; i--) {
+        if (
+          instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
+          !instances[i].buildVersion.includes(latestClientTag)
+        ) {
+          // After the cutoff day a node operator still run an instance with an
+          // older version. No rewards.
+          requirements.set(IS_VERSION_SATISFIED, false)
+          // No need to check further since at least one instance run on the
+          // older version after the cutoff day.
+          break
+        } else {
+          // It might happen that a node operator stopped an instance before the
+          // upgrade cutoff date that happens to be right before the interval
+          // end date. However, it might still be eligible for rewards because
+          // of the uptime requirement.
+          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+            requirements.set(IS_VERSION_SATISFIED, false)
+            // No need to check other instances because at least one instance run
+            // on the older version than 2 latest allowed.
+            break
+          }
+        }
+      }
+    } else {
+      // E.g. Feb interval
+      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
+      // --|-----------------------|---------------|------------|-->
+      //  Feb1                latest tag         Feb28        cutoff
+
+      // For simplicity purposes all the instances can run on any of the eligible
+      // versions.
+      for (let i = instances.length - 1; i >= 0; i--) {
+        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+          requirements.set(IS_VERSION_SATISFIED, false)
+          // No need to check other instances because at least one instance run
+          // on a version that is no longer eligible in this rewards interval.
+          break
+        }
+      }
+    }
+
+    operatorData[stakingProvider] = {
+      applications: Object.fromEntries(authorizations),
+      instances: convertToObject(instancesData),
+      requirements: Object.fromEntries(requirements),
+    }
+
+    operatorsData.push(operatorData)
+  }
+
+  fs.writeFileSync(outputFile, JSON.stringify(operatorsData, null, 4))
+}
+
+async function getAuthorization(
+  application: Contract,
+  intervalEvents: any[],
+  postIntervalEvents: any[],
+  stakingProvider: string,
+  startRewardsBlock: number,
+  endRewardsBlock: number,
+  currentBlockNumber: number
+) {
+  if (intervalEvents.length > 0) {
+    return authorizationForRewardsInterval(
+      intervalEvents,
+      startRewardsBlock,
+      endRewardsBlock
+    )
+  }
+
+  // Events that were emitted between the [end:firstEventDate|currentDate] dates.
+  // This is used to fetch the authorization that was set during the rewards
+  // interval.
+  return await authorizationPostRewardsInterval(
+    postIntervalEvents,
+    application,
+    stakingProvider,
+    currentBlockNumber
+  )
+}
+
+// Calculates the weighted authorization for rewards interval based on events.
+// The general idea of weighted rewards calculation describes the following example.
+// Please note that this example operates on dates for simplicity purposes,
+// however the actual calculation is based on block numbers.
+// Ex.
+// events:         ^     ^      *    *   ^
+// timeline:  -|---|-----|------|----|---|--------|-->
+//         Sep 0   3     8      14  18   22       30
+// where: '^' denotes increase in authorization
+//        '*' denotes decrease in authorization
+//         0 -> Sep 1 at 00:00:00
+// event authorizations:
+//  Sep 0 - 3 from 100k to 110k
+//  Sep 3 - 8 from 110k to 135k
+//  Sep 8 - 14 from 135k to 120k
+//  Sep 14 - 18 from 120k to 100k
+//  Sep 18 - 30 constant 100k (last sub-interval)
+// Weighted authorization = (3-0)/30*100 + (8-3)/30*110 + (14-8)/30*135
+//                        + (18-14)/30*120 + (30-18)/30*100
+function authorizationForRewardsInterval(
+  intervalEvents: any[],
+  startRewardsBlock: number,
+  endRewardsBlock: number
+) {
+  let authorization = BigNumber.from("0")
+  const deltaRewardsBlock = endRewardsBlock - startRewardsBlock
+  // ascending order
+  intervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
+
+  let tmpBlock = startRewardsBlock // prev tmp block
+
+  let index = 0
+
+  for (let i = index; i < intervalEvents.length; i++) {
+    const eventBlock = intervalEvents[i].blockNumber
+    const coefficient = Math.floor(
+      ((eventBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
+    )
+    authorization = authorization.add(
+      intervalEvents[i].args.fromAmount.mul(coefficient)
+    )
+    tmpBlock = eventBlock
+  }
+
+  // calculating authorization for the last sub-interval
+  const coefficient = Math.floor(
+    ((endRewardsBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
+  )
+  authorization = authorization.add(
+    intervalEvents[intervalEvents.length - 1].args.toAmount.mul(coefficient)
+  )
+
+  return authorization.div(PRECISION)
+}
+
+// Get the authorization from the first event that occurred after the rewards
+// interval. If no events were emitted, then get the authorization from the current
+// block.
+async function authorizationPostRewardsInterval(
+  postIntervalEvents: any[],
+  application: Contract,
+  stakingProvider: string,
+  currentBlockNumber: number
+) {
+  // Sort events in ascending order
+  postIntervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
+
+  if (
+    postIntervalEvents.length > 0 &&
+    postIntervalEvents[0].blockNumber < currentBlockNumber
+  ) {
+    // There are events (increase or decrease) present after the rewards interval
+    // and before the current block. Take the "fromAmount", because it was the
+    // same as for the rewards interval dates.
+    return postIntervalEvents[0].args.fromAmount
+  }
+
+  // There were no authorization events after the rewards interval and before
+  // the current block.
+  // Current authorization is the same as the authorization at the end of the
+  // rewards interval.
+  const authorization = await application.eligibleStake(stakingProvider)
+  return authorization
+}
+
+async function instancesForOperator(
+  operatorAddress: any,
+  rewardsInterval: number,
+  instancesData: Map<string, InstanceParams>
+) {
+  // Resolution is defaulted to Prometheus settings.
+  const instancesDataByOperatorParams = {
+    query: `present_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
+                [${rewardsInterval}s] offset ${offset}s)`,
+  }
+  const instancesDataByOperator = (
+    await queryPrometheus(prometheusAPIQuery, instancesDataByOperatorParams)
+  ).data.result
+
+  instancesDataByOperator.forEach(
+    (element: { metric: { instance: string } }) => {
+      const instanceData = {}
+      instancesData.set(element.metric.instance, instanceData as InstanceParams)
+    }
+  )
+}
+
+// Peer uptime requirement. The total uptime for all the instances for a given
+// operator has to be greater than 96% to receive the rewards.
+async function checkUptime(
+  operatorAddress: string,
+  rewardsInterval: number,
+  instancesData: Map<string, InstanceParams>
+) {
+  const paramsOperatorUptime = {
+    query: `up{chain_address="${operatorAddress}", job="${prometheusJob}"}
+            [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
+  }
+
+  const instances = (
+    await queryPrometheus(prometheusAPIQuery, paramsOperatorUptime)
+  ).data.result
+
+  // First registered 'up' metric in a given interval <start:end> for a given
+  // operator. Start evaluating uptime from this point.
+  const firstRegisteredUptime = instances.reduce(
+    (currentMin: number, instance: any) =>
+      Math.min(instance.values[0][0], currentMin),
+    Number.MAX_VALUE
+  )
+
+  let uptimeSearchRange = endRewardsTimestamp - firstRegisteredUptime
+
+  const paramsSumUptimes = {
+    query: `sum_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
+            [${uptimeSearchRange}s:${QUERY_RESOLUTION}s] offset ${offset}s)
+            * ${QUERY_RESOLUTION} / ${uptimeSearchRange}`,
+  }
+
+  const uptimesByInstance = (
+    await queryPrometheus(prometheusAPIQuery, paramsSumUptimes)
+  ).data.result
+
+  let sumUptime = 0
+  for (let i = 0; i < uptimesByInstance.length; i++) {
+    const instance = uptimesByInstance[i]
+    const uptime = instance.value[1] * HUNDRED
+    const dataInstance = instancesData.get(instance.metric.instance)
+    if (dataInstance !== undefined) {
+      dataInstance.upTimePercent = uptime
+    } else {
+      // Should not happen
+      console.error("Instance must be present for a given rewards interval.")
+    }
+
+    sumUptime += uptime
+  }
+
+  const isUptimeSatisfied = sumUptime >= requiredUptime
+
+  const uptimeCoefficient = isUptimeSatisfied
+    ? uptimeSearchRange / rewardsInterval
+    : 0
+  return { uptimeCoefficient, isUptimeSatisfied }
+}
+
+async function checkPreParams(
+  operatorAddress: string,
+  rewardsInterval: number,
+  dataInstances: Map<string, InstanceParams>
+) {
+  // Avg of pre-params across all the instances for a given operator in the rewards
+  // interval dates. Resolution is defaulted to Prometheus settings.
+  const paramsPreParams = {
+    query: `avg_over_time(tbtc_pre_params_count{chain_address="${operatorAddress}", job="${prometheusJob}"}
+              [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s)`,
+  }
+
+  const preParamsAvgByInstance = (
+    await queryPrometheus(prometheusAPIQuery, paramsPreParams)
+  ).data.result
+
+  let sumPreParams = 0
+  for (let i = 0; i < preParamsAvgByInstance.length; i++) {
+    const instance = preParamsAvgByInstance[i]
+    const preParams = parseInt(instance.value[1]) // [timestamp, value]
+    const dataInstance = dataInstances.get(instance.metric.instance)
+    if (dataInstance !== undefined) {
+      dataInstance.avgPreParams = preParams
+    } else {
+      // Should not happen
+      console.error("Instance must be present for a given rewards interval.")
+    }
+
+    sumPreParams += preParams
+  }
+
+  const preParamsAvg = sumPreParams / preParamsAvgByInstance.length
+  return preParamsAvg >= requiredPreParams
+}
+
+// Query Prometheus and fetch instances that run on either of two latest client
+// versions and mark their first and last registered timestamp.
+async function processBuildVersions(
+  operatorAddress: string,
+  rewardsInterval: number,
+  instancesData: Map<string, InstanceParams>
+) {
+  const buildVersionInstancesParams = {
+    query: `client_info{chain_address="${operatorAddress}", job="${prometheusJob}"}[${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
+  }
+  // Get instances data for a given rewards interval
+  const queryBuildVersionInstances = (
+    await queryPrometheus(prometheusAPIQuery, buildVersionInstancesParams)
+  ).data.result
+
+  let instances = []
+  const lastRegisteredVersion = new Map<string, string>() // version -> last registered timestamp
+
+  // Determine client's build version for it all it's instances
+  for (let i = 0; i < queryBuildVersionInstances.length; i++) {
+    const instance = queryBuildVersionInstances[i]
+
+    const instanceTimestampsVersionInfo = {
+      // First timestamp registered by Prometheus for a given instance
+      firstRegisteredTimestamp: instance.values[0][0],
+      // Last timestamp registered by Prometheus for a given instance
+      lastRegisteredTimestamp: instance.values[instance.values.length - 1][0],
+      buildVersion: instance.metric.version,
+    }
+
+    instances.push(instanceTimestampsVersionInfo)
+
+    const dataInstance = instancesData.get(instance.metric.instance)
+    lastRegisteredVersion.set(
+      instanceTimestampsVersionInfo.buildVersion,
+      instanceTimestampsVersionInfo.lastRegisteredTimestamp
+    )
+    if (dataInstance !== undefined) {
+      dataInstance.version = Object.fromEntries(lastRegisteredVersion)
+    } else {
+      // Should not happen
+      console.error("Instance must be present for a given rewards interval.")
+    }
+  }
+
+  // Sort instances in ascending order by first registration timestamp
+  instances.sort((a, b) =>
+    a.firstRegisteredTimestamp > b.firstRegisteredTimestamp ? 1 : -1
+  )
+
+  return instances
+}
+
+function convertToObject(map: Map<string, InstanceParams>) {
+  let obj: { [k: string]: any } = {}
+  map.forEach((value: InstanceParams, key: string) => {
+    obj[key] = value
+  })
+
+  return obj
+}
+
+async function queryPrometheus(url: string, params: any): Promise<any> {
+  try {
+    const { data } = await axios.get(url, { params: params })
+
+    return data
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.log("error message: ", error.message)
+      return error.message
+    } else {
+      console.log("unexpected error: ", error)
+      return "An unexpected error occurred"
+    }
+  }
+}
+
+// Special case: Dec 1st 23 distribution
+// When legacy stakes (Keep and Nu staking) were deactivated from Threshold
+// staking, the T tokens staked in the contract and that came from the legacy
+// tokens (keepInT, nuInT in the contract) were unstaked.
+// In addition to this, those legacy tokens that were part of Threshold apps
+// authorizations (walletRegistry, randomBeacon) are no longer part of the
+// authorization.
+// But no `AuthorizationDecreaseApproved` events where emitted, but a special
+// event "AuthorizationInvoluntaryDecreased". So the script were not able to
+// correctly calculate the authorization for this period.
+
+// Transaction in which legacy stakes were disabled:
+// https://etherscan.io/tx/0x68ddee6b5651d5348a40555b0079b5066d05a63196e3832323afafae0095a656
+// async function getLegacyEvents(provider: ethers.providers.EtherscanProvider) {
+//   const legacyTxHash =
+//     "0x68ddee6b5651d5348a40555b0079b5066d05a63196e3832323afafae0095a656"
+//   const eventSignature =
+//     "0x0f0171fffaa54732b1f79a3164b315658061a1a51bf8c1010fbed908a8e333f9"
+//   const legacyTxReceipt = await provider.getTransactionReceipt(legacyTxHash)
+
+//   const legacyEvents = legacyTxReceipt.logs
+//     .filter((log) => log.topics[0] === eventSignature)
+//     .map((legacyEvent) => {
+//       const parsedArgs = {
+//         stakingProvider: ethers.utils.getAddress(
+//           "0x" + legacyEvent.topics[1].slice(-40)
+//         ),
+//         application: ethers.utils.getAddress(
+//           "0x" + legacyEvent.topics[2].slice(-40)
+//         ),
+//         fromAmount: ethers.BigNumber.from(legacyEvent.data.slice(0, 66)),
+//         toAmount: ethers.BigNumber.from("0x" + legacyEvent.data.slice(66)),
+//       }
+
+//       return {
+//         ...legacyEvent,
+//         args: parsedArgs,
+//       } as unknown as ethers.Event
+//     })
+
+//   return legacyEvents
+// }
+
+calculateRewards()

--- a/src/scripts/tbtcv2-rewards/requirements.ts
+++ b/src/scripts/tbtcv2-rewards/requirements.ts
@@ -91,7 +91,7 @@ type InstanceParams = {
   version: any
 }
 
-export async function calculateRewards() {
+export async function calculateRequirements() {
   if (Date.now() / 1000 < endRewardsTimestamp) {
     console.log("End time interval must be in the past")
     return "End time interval must be in the past"
@@ -447,6 +447,16 @@ export async function calculateRewards() {
     operatorsData.push(operatorData)
   }
 
+  // insert params for requirements calculation as first element
+  operatorsData.unshift({
+    requiredUptime: requiredUptime,
+    operatorAddress: operatorAddress,
+    startRewardsBlock: startRewardsBlock,
+    endRewardsBlock: endRewardsBlock,
+    startRewardsTimestamp: startRewardsTimestamp,
+    endRewardsTimestamp: endRewardsTimestamp,
+  })
+
   fs.writeFileSync(outputFile, JSON.stringify(operatorsData, null, 4))
 }
 
@@ -800,4 +810,4 @@ async function queryPrometheus(url: string, params: any): Promise<any> {
 //   return legacyEvents
 // }
 
-calculateRewards()
+calculateRequirements()

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -15,7 +15,6 @@ import {
   abi as TokenStakingABI,
   address as TokenStakingAddress,
 } from "@threshold-network/solidity-contracts/artifacts/TokenStaking.json"
-import axios from "axios"
 import {
   BEACON_AUTHORIZATION,
   TBTC_AUTHORIZATION,
@@ -24,14 +23,14 @@ import {
   IS_UP_TIME_SATISFIED,
   IS_PRE_PARAMS_SATISFIED,
   IS_VERSION_SATISFIED,
-  ALLOWED_UPGRADE_DELAY,
   PRECISION,
   OPERATORS_SEARCH_QUERY_STEP,
-  QUERY_RESOLUTION,
   HUNDRED,
   APR,
   SECONDS_IN_YEAR,
 } from "./rewards-constants"
+import { InstanceParams } from "./types"
+import { Utils } from "./utils"
 
 program
   .version("0.0.1")
@@ -87,11 +86,15 @@ const prometheusAPIQuery = `${prometheusAPI}/query`
 // rewards interval dates.
 const offset = Math.floor(Date.now() / 1000) - endRewardsTimestamp
 
-type InstanceParams = {
-  upTimePercent: number
-  avgPreParams: number
-  version: any
-}
+const utils = new Utils(
+  prometheusAPI,
+  prometheusAPIQuery,
+  prometheusJob,
+  offset,
+  endRewardsTimestamp,
+  requiredUptime,
+  requiredPreParams
+)
 
 export async function calculateRewards() {
   if (Date.now() / 1000 < endRewardsTimestamp) {
@@ -121,7 +124,7 @@ export async function calculateRewards() {
   }
 
   const bootstrapData = (
-    await queryPrometheus(queryBootstrapData, paramsBootstrapData)
+    await utils.queryPrometheus(queryBootstrapData, paramsBootstrapData)
   ).data.result
 
   const operatorsData = new Array()
@@ -281,7 +284,7 @@ export async function calculateRewards() {
       )
     }
 
-    const beaconAuthorization = await getAuthorization(
+    const beaconAuthorization = await utils.getAuthorization(
       randomBeacon,
       beaconIntervalEvents,
       beaconPostIntervalEvents,
@@ -308,7 +311,7 @@ export async function calculateRewards() {
       )
     }
 
-    const tbtcAuthorization = await getAuthorization(
+    const tbtcAuthorization = await utils.getAuthorization(
       walletRegistry,
       tbtcIntervalEvents,
       tbtcPostIntervalEvents,
@@ -324,10 +327,14 @@ export async function calculateRewards() {
     /// Off-chain client reqs
 
     // Populate instances for a given operator.
-    await instancesForOperator(operatorAddress, rewardsInterval, instancesData)
+    await utils.instancesForOperator(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
 
     /// Uptime requirement
-    let { uptimeCoefficient, isUptimeSatisfied } = await checkUptime(
+    let { uptimeCoefficient, isUptimeSatisfied } = await utils.checkUptime(
       operatorAddress,
       rewardsInterval,
       instancesData
@@ -338,7 +345,7 @@ export async function calculateRewards() {
     requirements.set(IS_UP_TIME_SATISFIED, isUptimeSatisfied)
 
     /// Pre-params requirement
-    const isPrePramsSatisfied = await checkPreParams(
+    const isPrePramsSatisfied = await utils.checkPreParams(
       operatorAddress,
       rewardsInterval,
       instancesData
@@ -346,96 +353,22 @@ export async function calculateRewards() {
 
     requirements.set(IS_PRE_PARAMS_SATISFIED, isPrePramsSatisfied)
 
-    // keep-core client already has at least 2 released versions
-    const latestClient = clientReleases[0].split("_")
-    const latestClientTag = latestClient[0]
-    const latestClientTagTimestamp = Number(latestClient[1])
-    const secondToLatestClient = clientReleases[1].split("_")
-    const secondToLatestClientTag = secondToLatestClient[0]
-
-    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
-
-    if (clientReleases.length == 3) {
-      const thirdToLatestClient = clientReleases[2].split("_")
-      const thirdToLatestClientTag = thirdToLatestClient[0]
-      eligibleClientTags.push(thirdToLatestClientTag)
-    }
-
-    const instances = await processBuildVersions(
-      operatorAddress,
-      rewardsInterval,
-      instancesData
+    requirements.set(
+      IS_VERSION_SATISFIED,
+      await utils.isVersionSatisfied(
+        operatorAddress,
+        rewardsInterval,
+        startRewardsTimestamp,
+        endRewardsTimestamp,
+        clientReleases,
+        instancesData
+      )
     )
-
-    const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
-    requirements.set(IS_VERSION_SATISFIED, true)
-    if (upgradeCutoffDate < startRewardsTimestamp) {
-      // E.g. Feb interval
-      // ---older eligible tags---|----------latest tag only--------------|
-      // ---|---------------------|---------|-----------------------------|--->
-      // latest tag             cutoff     Feb1                         Feb28
-
-      // All the instances must run on the latest version during the rewards
-      // interval in Feb.
-      for (let i = 0; i < instances.length; i++) {
-        if (instances[i].buildVersion != latestClientTag) {
-          requirements.set(IS_VERSION_SATISFIED, false)
-        }
-      }
-    } else if (upgradeCutoffDate < endRewardsTimestamp) {
-      // E.g. Feb interval
-      // -----older eligible tags-----|----latest tag only----|
-      // ----|---------|--------------|-----------------------|--->
-      // latest tag   Feb1          cutoff                   Feb28
-
-      // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
-      // must run on the latest version
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (
-          instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
-          !instances[i].buildVersion.includes(latestClientTag)
-        ) {
-          // After the cutoff day a node operator still run an instance with an
-          // older version. No rewards.
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check further since at least one instance run on the
-          // older version after the cutoff day.
-          break
-        } else {
-          // It might happen that a node operator stopped an instance before the
-          // upgrade cutoff date that happens to be right before the interval
-          // end date. However, it might still be eligible for rewards because
-          // of the uptime requirement.
-          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
-            requirements.set(IS_VERSION_SATISFIED, false)
-            // No need to check other instances because at least one instance run
-            // on the older version than 2 latest allowed.
-            break
-          }
-        }
-      }
-    } else {
-      // E.g. Feb interval
-      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
-      // --|-----------------------|---------------|------------|-->
-      //  Feb1                latest tag         Feb28        cutoff
-
-      // For simplicity purposes all the instances can run on any of the eligible
-      // versions.
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check other instances because at least one instance run
-          // on a version that is no longer eligible in this rewards interval.
-          break
-        }
-      }
-    }
 
     /// Start assembling peer data and weighted authorizations
     operatorData[stakingProvider] = {
       applications: Object.fromEntries(authorizations),
-      instances: convertToObject(instancesData),
+      instances: utils.convertToObject(instancesData),
       requirements: Object.fromEntries(requirements),
     }
 
@@ -475,313 +408,6 @@ export async function calculateRewards() {
     rewardsDetailsPath + "/" + detailsFileName + ".json",
     JSON.stringify(operatorsData, null, 4)
   )
-}
-
-async function getAuthorization(
-  application: Contract,
-  intervalEvents: any[],
-  postIntervalEvents: any[],
-  stakingProvider: string,
-  startRewardsBlock: number,
-  endRewardsBlock: number,
-  currentBlockNumber: number
-) {
-  if (intervalEvents.length > 0) {
-    return authorizationForRewardsInterval(
-      intervalEvents,
-      startRewardsBlock,
-      endRewardsBlock
-    )
-  }
-
-  // Events that were emitted between the [end:firstEventDate|currentDate] dates.
-  // This is used to fetch the authorization that was set during the rewards
-  // interval.
-  return await authorizationPostRewardsInterval(
-    postIntervalEvents,
-    application,
-    stakingProvider,
-    currentBlockNumber
-  )
-}
-
-// Calculates the weighted authorization for rewards interval based on events.
-// The general idea of weighted rewards calculation describes the following example.
-// Please note that this example operates on dates for simplicity purposes,
-// however the actual calculation is based on block numbers.
-// Ex.
-// events:         ^     ^      *    *   ^
-// timeline:  -|---|-----|------|----|---|--------|-->
-//         Sep 0   3     8      14  18   22       30
-// where: '^' denotes increase in authorization
-//        '*' denotes decrease in authorization
-//         0 -> Sep 1 at 00:00:00
-// event authorizations:
-//  Sep 0 - 3 from 100k to 110k
-//  Sep 3 - 8 from 110k to 135k
-//  Sep 8 - 14 from 135k to 120k
-//  Sep 14 - 18 from 120k to 100k
-//  Sep 18 - 30 constant 100k (last sub-interval)
-// Weighted authorization = (3-0)/30*100 + (8-3)/30*110 + (14-8)/30*135
-//                        + (18-14)/30*120 + (30-18)/30*100
-function authorizationForRewardsInterval(
-  intervalEvents: any[],
-  startRewardsBlock: number,
-  endRewardsBlock: number
-) {
-  let authorization = BigNumber.from("0")
-  const deltaRewardsBlock = endRewardsBlock - startRewardsBlock
-  // ascending order
-  intervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
-
-  let tmpBlock = startRewardsBlock // prev tmp block
-
-  let index = 0
-
-  for (let i = index; i < intervalEvents.length; i++) {
-    const eventBlock = intervalEvents[i].blockNumber
-    const coefficient = Math.floor(
-      ((eventBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
-    )
-    authorization = authorization.add(
-      intervalEvents[i].args.fromAmount.mul(coefficient)
-    )
-    tmpBlock = eventBlock
-  }
-
-  // calculating authorization for the last sub-interval
-  const coefficient = Math.floor(
-    ((endRewardsBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
-  )
-  authorization = authorization.add(
-    intervalEvents[intervalEvents.length - 1].args.toAmount.mul(coefficient)
-  )
-
-  return authorization.div(PRECISION)
-}
-
-// Get the authorization from the first event that occurred after the rewards
-// interval. If no events were emitted, then get the authorization from the current
-// block.
-async function authorizationPostRewardsInterval(
-  postIntervalEvents: any[],
-  application: Contract,
-  stakingProvider: string,
-  currentBlockNumber: number
-) {
-  // Sort events in ascending order
-  postIntervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
-
-  if (
-    postIntervalEvents.length > 0 &&
-    postIntervalEvents[0].blockNumber < currentBlockNumber
-  ) {
-    // There are events (increase or decrease) present after the rewards interval
-    // and before the current block. Take the "fromAmount", because it was the
-    // same as for the rewards interval dates.
-    return postIntervalEvents[0].args.fromAmount
-  }
-
-  // There were no authorization events after the rewards interval and before
-  // the current block.
-  // Current authorization is the same as the authorization at the end of the
-  // rewards interval.
-  const authorization = await application.eligibleStake(stakingProvider)
-  return authorization
-}
-
-async function instancesForOperator(
-  operatorAddress: any,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  // Resolution is defaulted to Prometheus settings.
-  const instancesDataByOperatorParams = {
-    query: `present_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-                [${rewardsInterval}s] offset ${offset}s)`,
-  }
-  const instancesDataByOperator = (
-    await queryPrometheus(prometheusAPIQuery, instancesDataByOperatorParams)
-  ).data.result
-
-  instancesDataByOperator.forEach(
-    (element: { metric: { instance: string } }) => {
-      const instanceData = {}
-      instancesData.set(element.metric.instance, instanceData as InstanceParams)
-    }
-  )
-}
-
-// Peer uptime requirement. The total uptime for all the instances for a given
-// operator has to be greater than 96% to receive the rewards.
-async function checkUptime(
-  operatorAddress: string,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  const paramsOperatorUptime = {
-    query: `up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-            [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
-  }
-
-  const instances = (
-    await queryPrometheus(prometheusAPIQuery, paramsOperatorUptime)
-  ).data.result
-
-  // First registered 'up' metric in a given interval <start:end> for a given
-  // operator. Start evaluating uptime from this point.
-  const firstRegisteredUptime = instances.reduce(
-    (currentMin: number, instance: any) =>
-      Math.min(instance.values[0][0], currentMin),
-    Number.MAX_VALUE
-  )
-
-  let uptimeSearchRange = endRewardsTimestamp - firstRegisteredUptime
-
-  const paramsSumUptimes = {
-    query: `sum_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}
-            [${uptimeSearchRange}s:${QUERY_RESOLUTION}s] offset ${offset}s)
-            * ${QUERY_RESOLUTION} / ${uptimeSearchRange}`,
-  }
-
-  const uptimesByInstance = (
-    await queryPrometheus(prometheusAPIQuery, paramsSumUptimes)
-  ).data.result
-
-  let sumUptime = 0
-  for (let i = 0; i < uptimesByInstance.length; i++) {
-    const instance = uptimesByInstance[i]
-    const uptime = instance.value[1] * HUNDRED
-    const dataInstance = instancesData.get(instance.metric.instance)
-    if (dataInstance !== undefined) {
-      dataInstance.upTimePercent = uptime
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-
-    sumUptime += uptime
-  }
-
-  const isUptimeSatisfied = sumUptime >= requiredUptime
-
-  const uptimeCoefficient = isUptimeSatisfied
-    ? uptimeSearchRange / rewardsInterval
-    : 0
-  return { uptimeCoefficient, isUptimeSatisfied }
-}
-
-async function checkPreParams(
-  operatorAddress: string,
-  rewardsInterval: number,
-  dataInstances: Map<string, InstanceParams>
-) {
-  // Avg of pre-params across all the instances for a given operator in the rewards
-  // interval dates. Resolution is defaulted to Prometheus settings.
-  const paramsPreParams = {
-    query: `avg_over_time(tbtc_pre_params_count{chain_address="${operatorAddress}", job="${prometheusJob}"}
-              [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s)`,
-  }
-
-  const preParamsAvgByInstance = (
-    await queryPrometheus(prometheusAPIQuery, paramsPreParams)
-  ).data.result
-
-  let sumPreParams = 0
-  for (let i = 0; i < preParamsAvgByInstance.length; i++) {
-    const instance = preParamsAvgByInstance[i]
-    const preParams = parseInt(instance.value[1]) // [timestamp, value]
-    const dataInstance = dataInstances.get(instance.metric.instance)
-    if (dataInstance !== undefined) {
-      dataInstance.avgPreParams = preParams
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-
-    sumPreParams += preParams
-  }
-
-  const preParamsAvg = sumPreParams / preParamsAvgByInstance.length
-  return preParamsAvg >= requiredPreParams
-}
-
-// Query Prometheus and fetch instances that run on either of two latest client
-// versions and mark their first and last registered timestamp.
-async function processBuildVersions(
-  operatorAddress: string,
-  rewardsInterval: number,
-  instancesData: Map<string, InstanceParams>
-) {
-  const buildVersionInstancesParams = {
-    query: `client_info{chain_address="${operatorAddress}", job="${prometheusJob}"}[${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${offset}s`,
-  }
-  // Get instances data for a given rewards interval
-  const queryBuildVersionInstances = (
-    await queryPrometheus(prometheusAPIQuery, buildVersionInstancesParams)
-  ).data.result
-
-  let instances = []
-  const lastRegisteredVersion = new Map<string, string>() // version -> last registered timestamp
-
-  // Determine client's build version for it all it's instances
-  for (let i = 0; i < queryBuildVersionInstances.length; i++) {
-    const instance = queryBuildVersionInstances[i]
-
-    const instanceTimestampsVersionInfo = {
-      // First timestamp registered by Prometheus for a given instance
-      firstRegisteredTimestamp: instance.values[0][0],
-      // Last timestamp registered by Prometheus for a given instance
-      lastRegisteredTimestamp: instance.values[instance.values.length - 1][0],
-      buildVersion: instance.metric.version,
-    }
-
-    instances.push(instanceTimestampsVersionInfo)
-
-    const dataInstance = instancesData.get(instance.metric.instance)
-    lastRegisteredVersion.set(
-      instanceTimestampsVersionInfo.buildVersion,
-      instanceTimestampsVersionInfo.lastRegisteredTimestamp
-    )
-    if (dataInstance !== undefined) {
-      dataInstance.version = Object.fromEntries(lastRegisteredVersion)
-    } else {
-      // Should not happen
-      console.error("Instance must be present for a given rewards interval.")
-    }
-  }
-
-  // Sort instances in ascending order by first registration timestamp
-  instances.sort((a, b) =>
-    a.firstRegisteredTimestamp > b.firstRegisteredTimestamp ? 1 : -1
-  )
-
-  return instances
-}
-
-function convertToObject(map: Map<string, InstanceParams>) {
-  let obj: { [k: string]: any } = {}
-  map.forEach((value: InstanceParams, key: string) => {
-    obj[key] = value
-  })
-
-  return obj
-}
-
-async function queryPrometheus(url: string, params: any): Promise<any> {
-  try {
-    const { data } = await axios.get(url, { params: params })
-
-    return data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      console.log("error message: ", error.message)
-      return error.message
-    } else {
-      console.log("unexpected error: ", error)
-      return "An unexpected error occurred"
-    }
-  }
 }
 
 // Special case: Dec 1st 23 distribution

--- a/src/scripts/tbtcv2-rewards/staker2operator.sh
+++ b/src/scripts/tbtcv2-rewards/staker2operator.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eou pipefail
+
+LOG_START='\n\e[1;36m'           # new line + bold + color
+LOG_END='\n\e[0m'                # new line + reset color
+DONE_START='\n\e[1;32m'          # new line + bold + green
+DONE_END='\n\n\e[0m'             # new line + reset
+LOG_WARNING_START='\n\e\033[33m' # new line + bold + warning color
+LOG_WARNING_END='\n\e\033[0m'    # new line + reset
+
+NETWORK_DEFAULT="mainnet"
+
+help() {
+  echo -e "\nUsage: $0" \
+    "--etherscan-token <etherscan-token>" \
+    "--staker-address <staker-address>"
+  echo -e "\nRequired command line arguments:\n"
+  echo -e "\t--etherscan-token: Etherscan API key token"
+  echo -e "\t--staker-address: Staker address to report on." 
+  echo -e "\nOptional command line arguments:\n"
+  echo -e "\t--network: Network name. Default: ${NETWORK_DEFAULT}"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  "--etherscan-token") set -- "$@" "-t" ;;
+  "--staker-address") set -- "$@" "-x" ;;
+  "--network") set -- "$@" "-n" ;;
+  "--help") set -- "$@" "-h" ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "t:x:n:h" opt; do
+  case "$opt" in
+  t) etherscan_token="$OPTARG" ;;
+  x) staker_address="$OPTARG" ;;
+  n) network="$OPTARG" ;;
+  h) help ;;
+  ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+NETWORK=${network:-${NETWORK_DEFAULT}}
+ETHERSCAN_TOKEN=${etherscan_token:-""}
+STAKER_ADDRESS=${staker_address:-""}
+
+if [ "$STAKER_ADDRESS" == "" ]; then
+  printf "${LOG_WARNING_START}Staker address must be provided.${LOG_WARNING_END}"
+  help
+fi
+
+if [ "$ETHERSCAN_TOKEN" == "" ]; then
+  printf "${LOG_WARNING_START}Etherscan API key token must be provided.${LOG_WARNING_END}"
+  help
+fi
+
+printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
+yarn install
+
+ETHERSCAN_TOKEN=${ETHERSCAN_TOKEN} yarn staker2operator \
+  --staker-address ${STAKER_ADDRESS} \
+  --network ${NETWORK}
+
+printf "${DONE_START}Complete!${DONE_END}"

--- a/src/scripts/tbtcv2-rewards/staker2operator.ts
+++ b/src/scripts/tbtcv2-rewards/staker2operator.ts
@@ -1,0 +1,67 @@
+import { Contract } from "ethers"
+import { program } from "commander"
+import { ethers } from "ethers"
+import {
+  abi as RandomBeaconABI,
+  address as RandomBeaconAddress,
+} from "@keep-network/random-beacon/artifacts/RandomBeacon.json"
+import {
+  abi as WalletRegistryABI,
+  address as WalletRegistryAddress,
+} from "@keep-network/ecdsa/artifacts/WalletRegistry.json"
+
+program
+  .version("0.0.1")
+  .requiredOption("-x, --staker-address <address>", "staker address")
+  .requiredOption("-n, --network <network>", "mainnet, goerli, etc")
+  .parse(process.argv)
+
+// Parse the program options
+const options = program.opts()
+const stakerAddress = options.stakerAddress
+const network = options.network
+
+export async function staker2operator() {
+  const provider = new ethers.providers.EtherscanProvider(
+    network,
+    process.env.ETHERSCAN_TOKEN
+  )
+
+  const randomBeacon = new Contract(
+    RandomBeaconAddress,
+    JSON.stringify(RandomBeaconABI),
+    provider
+  )
+
+  const walletRegistry = new Contract(
+    WalletRegistryAddress,
+    JSON.stringify(WalletRegistryABI),
+    provider
+  )
+
+  // Staking provider should be the same for Beacon and TBTC apps
+  const operatorAddress = await randomBeacon.stakingProviderToOperator(
+    stakerAddress
+  )
+  const operatorAddressForTbtc = await walletRegistry.stakingProviderToOperator(
+    stakerAddress
+  )
+
+  if (operatorAddress !== operatorAddressForTbtc) {
+    console.log(
+      `Operator addresses for Beacon ${operatorAddress} and TBTC ${operatorAddressForTbtc} must match. `
+    )
+    return
+  }
+
+  if (operatorAddress === ethers.constants.AddressZero) {
+    console.log("Operator provider cannot be zero address. ")
+    return
+  }
+
+  console.log(
+    `Operator address for staker[${stakerAddress}] is ${operatorAddress}`
+  )
+}
+
+staker2operator()

--- a/src/scripts/tbtcv2-rewards/types.ts
+++ b/src/scripts/tbtcv2-rewards/types.ts
@@ -1,0 +1,5 @@
+export type InstanceParams = {
+  upTimePercent: number
+  avgPreParams: number
+  version: any
+}

--- a/src/scripts/tbtcv2-rewards/utils.ts
+++ b/src/scripts/tbtcv2-rewards/utils.ts
@@ -1,0 +1,472 @@
+import { BigNumber } from "@ethersproject/bignumber"
+import { Contract } from "ethers"
+import axios from "axios"
+import {
+  OPERATORS_SEARCH_QUERY_STEP,
+  QUERY_RESOLUTION,
+  HUNDRED,
+  PRECISION,
+  ALLOWED_UPGRADE_DELAY,
+} from "./rewards-constants"
+import { InstanceParams } from "./types"
+
+export class Utils {
+  prometheusAPI: string
+  prometheusAPIQuery: string
+  prometheusJob: string
+  offset: number
+  endRewardsTimestamp: number
+  requiredUptime: number
+  requiredPreParams: number
+
+  constructor(
+    prometheusApi: string,
+    prometheusAPIQuery: string,
+    prometheusJob: string,
+    offset: number,
+    endRewardsTimestamp: number,
+    requireUptime: number,
+    requiredPreParams: number
+  ) {
+    this.prometheusAPI = prometheusApi
+    this.prometheusAPIQuery = prometheusAPIQuery
+    this.prometheusJob = prometheusJob
+    this.offset = offset
+    this.endRewardsTimestamp = endRewardsTimestamp
+    this.requiredUptime = requireUptime
+    this.requiredPreParams = requiredPreParams
+  }
+
+  public async getAuthorization(
+    application: Contract,
+    intervalEvents: any[],
+    postIntervalEvents: any[],
+    stakingProvider: string,
+    startRewardsBlock: number,
+    endRewardsBlock: number,
+    currentBlockNumber: number
+  ) {
+    if (intervalEvents.length > 0) {
+      return this.authorizationForRewardsInterval(
+        intervalEvents,
+        startRewardsBlock,
+        endRewardsBlock
+      )
+    }
+
+    // Events that were emitted between the [end:firstEventDate|currentDate] dates.
+    // This is used to fetch the authorization that was set during the rewards
+    // interval.
+    return await this.authorizationPostRewardsInterval(
+      postIntervalEvents,
+      application,
+      stakingProvider,
+      currentBlockNumber
+    )
+  }
+
+  // Calculates the weighted authorization for rewards interval based on events.
+  // The general idea of weighted rewards calculation describes the following example.
+  // Please note that this example operates on dates for simplicity purposes,
+  // however the actual calculation is based on block numbers.
+  // Ex.
+  // events:         ^     ^      *    *   ^
+  // timeline:  -|---|-----|------|----|---|--------|-->
+  //         Sep 0   3     8      14  18   22       30
+  // where: '^' denotes increase in authorization
+  //        '*' denotes decrease in authorization
+  //         0 -> Sep 1 at 00:00:00
+  // event authorizations:
+  //  Sep 0 - 3 from 100k to 110k
+  //  Sep 3 - 8 from 110k to 135k
+  //  Sep 8 - 14 from 135k to 120k
+  //  Sep 14 - 18 from 120k to 100k
+  //  Sep 18 - 30 constant 100k (last sub-interval)
+  // Weighted authorization = (3-0)/30*100 + (8-3)/30*110 + (14-8)/30*135
+  //                        + (18-14)/30*120 + (30-18)/30*100
+  public authorizationForRewardsInterval(
+    intervalEvents: any[],
+    startRewardsBlock: number,
+    endRewardsBlock: number
+  ) {
+    let authorization = BigNumber.from("0")
+    const deltaRewardsBlock = endRewardsBlock - startRewardsBlock
+    // ascending order
+    intervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
+
+    let tmpBlock = startRewardsBlock // prev tmp block
+
+    let index = 0
+
+    for (let i = index; i < intervalEvents.length; i++) {
+      const eventBlock = intervalEvents[i].blockNumber
+      const coefficient = Math.floor(
+        ((eventBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
+      )
+      authorization = authorization.add(
+        intervalEvents[i].args.fromAmount.mul(coefficient)
+      )
+      tmpBlock = eventBlock
+    }
+
+    // calculating authorization for the last sub-interval
+    const coefficient = Math.floor(
+      ((endRewardsBlock - tmpBlock) / deltaRewardsBlock) * PRECISION
+    )
+    authorization = authorization.add(
+      intervalEvents[intervalEvents.length - 1].args.toAmount.mul(coefficient)
+    )
+
+    return authorization.div(PRECISION)
+  }
+
+  // Get the authorization from the first event that occurred after the rewards
+  // interval. If no events were emitted, then get the authorization from the current
+  // block.
+  public async authorizationPostRewardsInterval(
+    postIntervalEvents: any[],
+    application: Contract,
+    stakingProvider: string,
+    currentBlockNumber: number
+  ) {
+    // Sort events in ascending order
+    postIntervalEvents.sort((a, b) => a.blockNumber - b.blockNumber)
+
+    if (
+      postIntervalEvents.length > 0 &&
+      postIntervalEvents[0].blockNumber < currentBlockNumber
+    ) {
+      // There are events (increase or decrease) present after the rewards interval
+      // and before the current block. Take the "fromAmount", because it was the
+      // same as for the rewards interval dates.
+      return postIntervalEvents[0].args.fromAmount
+    }
+
+    // There were no authorization events after the rewards interval and before
+    // the current block.
+    // Current authorization is the same as the authorization at the end of the
+    // rewards interval.
+    const authorization = await application.eligibleStake(stakingProvider)
+    return authorization
+  }
+
+  public async instancesForOperator(
+    operatorAddress: any,
+    rewardsInterval: number,
+    instancesData: Map<string, InstanceParams>
+  ) {
+    // Resolution is defaulted to Prometheus settings.
+    const instancesDataByOperatorParams = {
+      query: `present_over_time(up{chain_address="${operatorAddress}", job="${this.prometheusJob}"}
+                [${rewardsInterval}s] offset ${this.offset}s)`,
+    }
+    const instancesDataByOperator = (
+      await this.queryPrometheus(
+        this.prometheusAPIQuery,
+        instancesDataByOperatorParams
+      )
+    ).data.result
+
+    instancesDataByOperator.forEach(
+      (element: { metric: { instance: string } }) => {
+        const instanceData = {}
+        instancesData.set(
+          element.metric.instance,
+          instanceData as InstanceParams
+        )
+      }
+    )
+  }
+
+  // Peer uptime requirement. The total uptime for all the instances for a given
+  // operator has to be greater than 96% to receive the rewards.
+  public async checkUptime(
+    operatorAddress: string,
+    rewardsInterval: number,
+    instancesData: Map<string, InstanceParams>
+  ) {
+    const paramsOperatorUptime = {
+      query: `up{chain_address="${operatorAddress}", job="${this.prometheusJob}"}
+            [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${this.offset}s`,
+    }
+
+    const instances = (
+      await this.queryPrometheus(this.prometheusAPIQuery, paramsOperatorUptime)
+    ).data.result
+
+    // First registered 'up' metric in a given interval <start:end> for a given
+    // operator. Start evaluating uptime from this point.
+    const firstRegisteredUptime = instances.reduce(
+      (currentMin: number, instance: any) =>
+        Math.min(instance.values[0][0], currentMin),
+      Number.MAX_VALUE
+    )
+
+    let uptimeSearchRange = this.endRewardsTimestamp - firstRegisteredUptime
+
+    const paramsSumUptimes = {
+      query: `sum_over_time(up{chain_address="${operatorAddress}", job="${this.prometheusJob}"}
+            [${uptimeSearchRange}s:${QUERY_RESOLUTION}s] offset ${this.offset}s)
+            * ${QUERY_RESOLUTION} / ${uptimeSearchRange}`,
+    }
+
+    const uptimesByInstance = (
+      await this.queryPrometheus(this.prometheusAPIQuery, paramsSumUptimes)
+    ).data.result
+
+    let sumUptime = 0
+    for (let i = 0; i < uptimesByInstance.length; i++) {
+      const instance = uptimesByInstance[i]
+      const uptime = instance.value[1] * HUNDRED
+      const dataInstance = instancesData.get(instance.metric.instance)
+      if (dataInstance !== undefined) {
+        dataInstance.upTimePercent = uptime
+      } else {
+        // Should not happen
+        console.error("Instance must be present for a given rewards interval.")
+      }
+
+      sumUptime += uptime
+    }
+
+    const isUptimeSatisfied = sumUptime >= this.requiredUptime
+
+    const uptimeCoefficient = isUptimeSatisfied
+      ? uptimeSearchRange / rewardsInterval
+      : 0
+    return { uptimeCoefficient, isUptimeSatisfied }
+  }
+
+  public async checkPreParams(
+    operatorAddress: string,
+    rewardsInterval: number,
+    dataInstances: Map<string, InstanceParams>
+  ) {
+    // Avg of pre-params across all the instances for a given operator in the rewards
+    // interval dates. Resolution is defaulted to Prometheus settings.
+    const paramsPreParams = {
+      query: `avg_over_time(tbtc_pre_params_count{chain_address="${operatorAddress}", job="${this.prometheusJob}"}
+              [${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${this.offset}s)`,
+    }
+
+    const preParamsAvgByInstance = (
+      await this.queryPrometheus(this.prometheusAPIQuery, paramsPreParams)
+    ).data.result
+
+    let sumPreParams = 0
+    for (let i = 0; i < preParamsAvgByInstance.length; i++) {
+      const instance = preParamsAvgByInstance[i]
+      const preParams = parseInt(instance.value[1]) // [timestamp, value]
+      const dataInstance = dataInstances.get(instance.metric.instance)
+      if (dataInstance !== undefined) {
+        dataInstance.avgPreParams = preParams
+      } else {
+        // Should not happen
+        console.error("Instance must be present for a given rewards interval.")
+      }
+
+      sumPreParams += preParams
+    }
+
+    const preParamsAvg = sumPreParams / preParamsAvgByInstance.length
+    return preParamsAvg >= this.requiredPreParams
+  }
+
+  // Query Prometheus and fetch instances that run on either of two latest client
+  // versions and mark their first and last registered timestamp.
+  public async processBuildVersions(
+    operatorAddress: string,
+    rewardsInterval: number,
+    instancesData: Map<string, InstanceParams>
+  ) {
+    const buildVersionInstancesParams = {
+      query: `client_info{chain_address="${operatorAddress}", job="${this.prometheusJob}"}[${rewardsInterval}s:${QUERY_RESOLUTION}s] offset ${this.offset}s`,
+    }
+    // Get instances data for a given rewards interval
+    const queryBuildVersionInstances = (
+      await this.queryPrometheus(
+        this.prometheusAPIQuery,
+        buildVersionInstancesParams
+      )
+    ).data.result
+
+    let instances = []
+    const lastRegisteredVersion = new Map<string, string>() // version -> last registered timestamp
+
+    // Determine client's build version for it all it's instances
+    for (let i = 0; i < queryBuildVersionInstances.length; i++) {
+      const instance = queryBuildVersionInstances[i]
+
+      const instanceTimestampsVersionInfo = {
+        // First timestamp registered by Prometheus for a given instance
+        firstRegisteredTimestamp: instance.values[0][0],
+        // Last timestamp registered by Prometheus for a given instance
+        lastRegisteredTimestamp: instance.values[instance.values.length - 1][0],
+        buildVersion: instance.metric.version,
+      }
+
+      instances.push(instanceTimestampsVersionInfo)
+
+      const dataInstance = instancesData.get(instance.metric.instance)
+      lastRegisteredVersion.set(
+        instanceTimestampsVersionInfo.buildVersion,
+        instanceTimestampsVersionInfo.lastRegisteredTimestamp
+      )
+      if (dataInstance !== undefined) {
+        dataInstance.version = Object.fromEntries(lastRegisteredVersion)
+      } else {
+        // Should not happen
+        console.error("Instance must be present for a given rewards interval.")
+      }
+    }
+
+    // Sort instances in ascending order by first registration timestamp
+    instances.sort((a, b) =>
+      a.firstRegisteredTimestamp > b.firstRegisteredTimestamp ? 1 : -1
+    )
+
+    return instances
+  }
+
+  public convertToObject(map: Map<string, InstanceParams>) {
+    let obj: { [k: string]: any } = {}
+    map.forEach((value: InstanceParams, key: string) => {
+      obj[key] = value
+    })
+
+    return obj
+  }
+
+  public async queryPrometheus(url: string, params: any): Promise<any> {
+    try {
+      const { data } = await axios.get(url, { params: params })
+
+      return data
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.log("error message: ", error.message)
+        return error.message
+      } else {
+        console.log("unexpected error: ", error)
+        return "An unexpected error occurred"
+      }
+    }
+  }
+
+  public async getBootstrapData(
+    startRewardsTimestamp: number,
+    endRewardsTimestamp: number
+  ) {
+    // Query for bootstrap data that has peer instances grouped by operators
+    const queryBootstrapData = `${this.prometheusAPI}/query_range`
+    const paramsBootstrapData = {
+      query: `sum by(chain_address)({job='${this.prometheusJob}'})`,
+      start: startRewardsTimestamp,
+      end: endRewardsTimestamp,
+      step: OPERATORS_SEARCH_QUERY_STEP,
+    }
+
+    const bootstrapData = await this.queryPrometheus(
+      queryBootstrapData,
+      paramsBootstrapData
+    )
+    return bootstrapData.data.result
+  }
+
+  public async isVersionSatisfied(
+    operatorAddress: string,
+    rewardsInterval: number,
+    startRewardsTimestamp: number,
+    endRewardsTimestamp: number,
+    clientReleases: any,
+    instancesData: Map<string, InstanceParams>
+  ) {
+    // keep-core client already has at least 2 released versions
+    const latestClient = clientReleases[0].split("_")
+    const latestClientTag = latestClient[0]
+    const latestClientTagTimestamp = Number(latestClient[1])
+    const secondToLatestClient = clientReleases[1].split("_")
+    const secondToLatestClientTag = secondToLatestClient[0]
+
+    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
+
+    if (clientReleases.length == 3) {
+      const thirdToLatestClient = clientReleases[2].split("_")
+      const thirdToLatestClientTag = thirdToLatestClient[0]
+      eligibleClientTags.push(thirdToLatestClientTag)
+    }
+
+    const instances = await this.processBuildVersions(
+      operatorAddress,
+      rewardsInterval,
+      instancesData
+    )
+
+    let isVersionSatisfied = true
+    const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
+    if (upgradeCutoffDate < startRewardsTimestamp) {
+      // E.g. Feb interval
+      // ---older eligible tags---|----------latest tag only--------------|
+      // ---|---------------------|---------|-----------------------------|--->
+      // latest tag             cutoff     Feb1                         Feb28
+
+      // All the instances must run on the latest version during the rewards
+      // interval in Feb.
+      for (let i = 0; i < instances.length; i++) {
+        if (instances[i].buildVersion != latestClientTag) {
+          isVersionSatisfied = false
+        }
+      }
+    } else if (upgradeCutoffDate < endRewardsTimestamp) {
+      // E.g. Feb interval
+      // -----older eligible tags-----|----latest tag only----|
+      // ----|---------|--------------|-----------------------|--->
+      // latest tag   Feb1          cutoff                   Feb28
+
+      // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
+      // must run on the latest version
+      for (let i = instances.length - 1; i >= 0; i--) {
+        if (
+          instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
+          !instances[i].buildVersion.includes(latestClientTag)
+        ) {
+          // After the cutoff day a node operator still run an instance with an
+          // older version. No rewards.
+          isVersionSatisfied = false
+          // No need to check further since at least one instance run on the
+          // older version after the cutoff day.
+          break
+        } else {
+          // It might happen that a node operator stopped an instance before the
+          // upgrade cutoff date that happens to be right before the interval
+          // end date. However, it might still be eligible for rewards because
+          // of the uptime requirement.
+          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+            isVersionSatisfied = false
+            // No need to check other instances because at least one instance run
+            // on the older version than 2 latest allowed.
+            break
+          }
+        }
+      }
+    } else {
+      // E.g. Feb interval
+      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
+      // --|-----------------------|---------------|------------|-->
+      //  Feb1                latest tag         Feb28        cutoff
+
+      // For simplicity purposes all the instances can run on any of the eligible
+      // versions.
+      for (let i = instances.length - 1; i >= 0; i--) {
+        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+          isVersionSatisfied = false
+          // No need to check other instances because at least one instance run
+          // on a version that is no longer eligible in this rewards interval.
+          break
+        }
+      }
+    }
+
+    return isVersionSatisfied
+  }
+}


### PR DESCRIPTION
This PR adds the ability for a node operator to easily check their current tbtc rewards requirements status based on the Source of Truth data used for rewards calculations.

The motivation is to improve transparency for node operators and provide an ability to monitor their nodes and act accordingly when a node is in danger of not meeting requirements. Nobody wants to get to the end of the month only to find that they have not met requirements.

See `src/scripts/tbtcv2-rewards/MONITORING.md` for details and instructions.

Summary of changes:

Created requirements.ts|sh for usage more appropriate to monitoring. This involved copying over rewards.ts|sh, removing unneeded code that only applied to monthly rewards, and using operator address instead of staker address. Use of staker address is not very performant for the monitoring use case because you have to loop through every operator address in the bootstrap data and make eth contract calls to resolve.

Created staker2operator.ts|sh to make it easy to obtain operator address from staker address

An important aspect of this PR is the refactoring of common code for both rewards.ts and requirements.ts to use. I did this so that changes in code that is used for rewards.ts also applies to requirements.ts, we don't want requirements monitoring to be forked from rewards code. I simply moved shared code to Utils as a low-cost way to do the refactor.

I verified that rewards.sh|ts are working, but this should be double-checked for merging this PR.