### PR TITLE
Add a workaround to support both versioning system

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -76,7 +76,7 @@ const prometheusAPI = options.api
 // Since the release of tBTC client v2.0.0, the versioning strategy has changed.
 // Previous versions had a -mX suffix, but this is no longer the case.
 // From now on, the versioning system is semantic versioning https://semver.org/
-// without suffixes, where it is mandatory the update of the client for new minor
+// without suffixes, where the update of the client is mandatory for new minor
 // versions, but optional for new patch versions.
 // Since this distribution of rewards (May 1st 2024) accepts as valid three
 // versions, one of the old versioning system (v2.0.0-m7) and two of the new

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -71,7 +71,25 @@ program
 const options = program.opts()
 const prometheusJob = options.job
 const prometheusAPI = options.api
-const clientReleases = options.releases.split("|") // sorted from latest to oldest
+
+// May 1st 2024 distribution special case:
+// Since the release of tBTC client v2.0.0, the versioning strategy has changed.
+// Previous versions had a -mX suffix, but this is no longer the case.
+// From now on, the versioning system is semantic versioning https://semver.org/
+// without suffixes, where it is mandatory the update of the client for new minor
+// versions, but optional for new patch versions.
+// Since this distribution of rewards (May 1st 2024) accepts as valid three
+// versions, one of the old versioning system (v2.0.0-m7) and two of the new
+// system (v2.0.0 and v2.0.1), we have implemented a workaround to support both
+// in this interim period.
+// After this distribution, the new semantic versioning system will be implemented.
+
+// const clientReleases = options.releases.split("|") // sorted from latest to oldest
+const clientReleases = [
+  "v2.0.0_1712275200", // v2.0.0 announced on April 5
+  "v2.0.0-m7_1707731729", // v2.0.0-m7 announced on Feb 12
+]
+
 const startRewardsTimestamp = parseInt(options.startTimestamp)
 const endRewardsTimestamp = parseInt(options.endTimestamp)
 const startRewardsBlock = parseInt(options.startBlock)
@@ -189,11 +207,6 @@ export async function calculateRewards() {
       currentBlockNumber
     )
 
-  // Special case: legacy stakes
-  // const legacyEvents = await getLegacyEvents(provider)
-
-  // For Dec 1st distribution, legacy stakes will not receive rewards.
-  // The corresponding rewards will be received in following distributions.
   const legacyEvents: ethers.Event[] = []
 
   const intervalLegacyEvents = legacyEvents.filter(
@@ -378,7 +391,11 @@ export async function calculateRewards() {
       // All the instances must run on the latest version during the rewards
       // interval in Feb.
       for (let i = 0; i < instances.length; i++) {
-        if (instances[i].buildVersion != latestClientTag) {
+        // May 1st 2024 distribution special case:
+        if (
+          instances[i].buildVersion != "v2.0.0" ||
+          instances[i].buildVersion != "v2.0.1"
+        ) {
           requirements.set(IS_VERSION_SATISFIED, false)
         }
       }
@@ -393,7 +410,11 @@ export async function calculateRewards() {
       for (let i = instances.length - 1; i >= 0; i--) {
         if (
           instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
-          !instances[i].buildVersion.includes(latestClientTag)
+          // May 1st 2024 distribution special case:
+          !(
+            instances[i].buildVersion === "v2.0.0" ||
+            instances[i].buildVersion === "v2.0.1"
+          )
         ) {
           // After the cutoff day a node operator still run an instance with an
           // older version. No rewards.
@@ -406,7 +427,12 @@ export async function calculateRewards() {
           // upgrade cutoff date that happens to be right before the interval
           // end date. However, it might still be eligible for rewards because
           // of the uptime requirement.
-          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+          // May 1st 2024 distribution special case:
+          if (
+            !["v2.0.1", "v2.0.0", "v2.0.0-m7"].includes(
+              instances[i].buildVersion
+            )
+          ) {
             requirements.set(IS_VERSION_SATISFIED, false)
             // No need to check other instances because at least one instance run
             // on the older version than 2 latest allowed.


### PR DESCRIPTION
May 1st 2024 distribution special case:

Since the release of tBTC client v2.0.0, the versioning strategy has changed. Previous versions had a -mX suffix, but this is no longer the case.

From now on, the versioning system is semantic versioning https://semver.org/ without suffixes, where it is mandatory the update of the client for new minor versions, but optional for new patch versions.

Since this distribution of rewards (May 1st 2024) accepts as valid three versions, one of the old versioning system (v2.0.0-m7) and two of the new system (v2.0.0 and v2.0.1), we have implemented a workaround to support both in this interim period.

After this distribution, the new semantic versioning system will be implemented.