### PR TITLE
Use semantic versioning to check tBTC client version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,47 @@ ETHERSCAN_TOKEN=<your Etherscan API token>
 This script calculates the Threshold Network rewards earned during a specific period, adds them to
 the previous distributions, and generates a new distribution that contains the cumulative rewards.
 
+```bash
+node src/scripts/gen_rewards_dist.js
+```
+
 Note that some script's parameters (rewards weights, start time, end time, last distribution path)
 must be replaced in the script before running it.
 
-```bash
-node src/scripts/gen_rewards_dist.js
+### Valid versions
+
+Additionally, the tBTC client valid versions must be specified. The `tbtcValidVersions` variable
+must be set for each distribution release. The versions must be specified following this schema:
+
+```
+<version1>|<version2>_<version2Deadline>|<version3>_<version3Dealine> ...
+```
+
+Where:
+
+- The versions must be sorted from latest to oldest.
+- <versionDeadline> is the deadline in UNIX timestamp until the version is valid.
+
+Examples:
+
+- For this release distribution, only v2.1.0 (and patch versions v2.1.1, v2.1.2, etc) are valid:
+
+```js
+const tbtcValidVersions = "v2.1.0"
+```
+
+- We are calculating June 2024 rewards. v2.1.x is the current version and v2.0.x is valid until
+2024-06-15:
+
+```js
+const tbtcValidVersions = "v2.1.0|v2.0.0_1718409600"
+```
+
+- We are calculating June 2024 rewards. v2.2.x is the current version. v2.1.x is valid until
+2024-06-20. v2.0.x is valid until 2024-06-10:
+
+```js
+const tbtcValidVersions = "v2.2.0|v2.1.0_1718841600|v2.0.0_1717977600"
 ```
 
 ### Contributions

--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -15,10 +15,12 @@ const tbtcv2Weight = 0.75
 const startTime = new Date("2024-04-01T00:00:00+00:00").getTime() / 1000
 const endTime = new Date("2024-05-01T00:00:00+00:00").getTime() / 1000
 const lastDistribution = "2024-04-01"
-// tBTC valid versions and deadlines (if any) sorted from latests to oldest:
-// Example: v2.1.0 is the current version, v2.0.x are valid until 2024-06-01
-// Example v2.1.0|v2.0.1_1717200000|v2.0.0_1717200000|
-const tbtcValidVersions = "v2.0.1|v2.0.0"
+// tBTC valid versions and deadlines (if any) sorted from latests to oldest.
+// Example: v2.1.x is the current version, v2.0.x is valid until 2024-06-01:
+// v2.1.0|v2.0.0_1717200000
+// Note that we only care about major and minor versions, so not updating to a
+// new patch version will not disqualify the stake for rewards.
+const tbtcValidVersions = "v2.0.0"
 
 const etherscanApiKey = process.env.ETHERSCAN_TOKEN
 const tbtcv2ScriptPath = "src/scripts/tbtcv2-rewards/"

--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -15,6 +15,10 @@ const tbtcv2Weight = 0.75
 const startTime = new Date("2024-04-01T00:00:00+00:00").getTime() / 1000
 const endTime = new Date("2024-05-01T00:00:00+00:00").getTime() / 1000
 const lastDistribution = "2024-04-01"
+// tBTC valid versions and deadlines (if any) sorted from latests to oldest:
+// Example: v2.1.0 is the current version, v2.0.x are valid until 2024-06-01
+// Example v2.1.0|v2.0.1_1717200000|v2.0.0_1717200000|
+const tbtcValidVersions = "v2.0.1|v2.0.0"
 
 const etherscanApiKey = process.env.ETHERSCAN_TOKEN
 const tbtcv2ScriptPath = "src/scripts/tbtcv2-rewards/"
@@ -40,7 +44,8 @@ async function main() {
     `--rewards-start-date ${startTime} ` +
     `--rewards-end-date ${endTime} ` +
     `--etherscan-token ${etherscanApiKey} ` +
-    `--rewards-details-path ../../../${tbtcv2RewardsDetailsPath}`
+    `--rewards-details-path ../../../${tbtcv2RewardsDetailsPath} ` +
+    `--valid-versions "${tbtcValidVersions}"`
 
   try {
     fs.mkdirSync(distPath)

--- a/src/scripts/tbtcv2-rewards/README.md
+++ b/src/scripts/tbtcv2-rewards/README.md
@@ -20,41 +20,38 @@ rewards interval
 ## Client build version
 
 Node operators must stay updated with the latest keep-core client releases to
-receive rewards. The cutoff day for a new version is calculated by adding three
-weeks to its tag creation date, which can be verified by executing the command
-`git show <tag>`.
+receive rewards. The cutoff day for a new version is specified with
+`--valid-versions` parameter following this schema:
 
-Note: There is an exception for the month of February, where a cutoff day to
-upgrade a client from `v2.0.0-m1` to `v2.0.0-m2` is until February 27th.
-
-Here are a few examples to demonstrate the build version requirement.
+The versions must be specified following this schema:
 
 ```
-E.g. 1
-                          v1                v1 or v2
-         ---------------------------------\|-------|
-Timeline -|--------------------------------*-------|->
-        May1                             May25   May31
-                                          v2
-Where:
-Rewards interval: May 1 - May 31
-v2 is released on May 25
-delay = 14 days
-v2 + delay = May24 + 14 days = June 8
-Between May 1 - May 25 a client runs on v1
-Between May 25 - May 31 a client is allowed to run on v1 or v2
+<version1>|<version2>_<version2Deadline>|<version3>_<version3Dealine> ...
+```
 
-E.g. 2
-                 v1 or v2                    v2
-         --/------------------\|---------------------------|
-Timeline -*--------|-----------*---------------------------|->
-        May25    June1       June8                      June30
-          v2               (v2+delay)
 Where:
-Rewards interval: June 1 - June 30
-v2 is released on May 25
-delay = 14 days
-v2 + delay = May 25 + 14 days = June 8
-Between June 1 - June 8 a client is allowed to run v1 or v2
-Between June 8 - June 30 a client is allowed to run only v2
+
+- The versions must be sorted from latest to oldest.
+- <versionDeadline> is the deadline in UNIX timestamp until the version is valid.
+
+Examples:
+
+- For this release distribution, only v2.1.0 (and patch versions v2.1.1, v2.1.2, etc) are valid:
+
+```js
+const tbtcValidVersions = "v2.1.0"
+```
+
+- We are calculating June 2024 rewards. v2.1.x is the current version and v2.0.x is valid until
+2024-06-15:
+
+```js
+const tbtcValidVersions = "v2.1.0|v2.0.0_1718409600"
+```
+
+- We are calculating June 2024 rewards. v2.2.x is the current version. v2.1.x is valid until
+2024-06-20. v2.0.x is valid until 2024-06-10:
+
+```js
+const tbtcValidVersions = "v2.2.0|v2.1.0_1718841600|v2.0.0_1717977600"
 ```

--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -1,4 +1,3 @@
-export const ALLOWED_UPGRADE_DELAY = 1814400 // 3 weeks in sec (default value)
 export const OPERATORS_SEARCH_QUERY_STEP = 600 // 10min in sec
 export const IS_BEACON_AUTHORIZED = "isBeaconAuthorized"
 export const BEACON_AUTHORIZATION = "beaconAuthorization"

--- a/src/scripts/tbtcv2-rewards/rewards.sh
+++ b/src/scripts/tbtcv2-rewards/rewards.sh
@@ -18,12 +18,6 @@ REWARDS_DETAILS_PATH_DEFAULT="./rewards-details"
 REQUIRED_PRE_PARAMS_DEFAULT=500
 REQUIRED_UPTIME_DEFAULT=96 # percent
 
-# TODO: REMOVE THIS
-# Default should be 2. In rare cases when we release a hot fix and all 3 tags
-# become eligible in a given interval, then it can be set to 3.
-# Script supports up to 3 tags.
-ELIGIBLE_NUMBER_OF_TAGS=2
-
 help() {
   echo -e "\nUsage: $0" \
     "--rewards-start-date <rewards-start-date timestamp>" \
@@ -156,39 +150,6 @@ endRewardsBlock=$(curl -s $endBlockApiCall | jq '.result|tonumber')
 
 printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
 yarn install
-
-# TODO: REMOVE THIS
-# printf "${LOG_START}Retrieving client release tags...${LOG_END}"
-# # Create a new git remote to fetch the release tags
-# git remote remove keep-core-repo 2>/dev/null || true
-# git remote add keep-core-repo ${KEEP_CORE_REPO}
-# git fetch --tags --prune --quiet keep-core-repo
-# allTags=($(git tag --sort=-version:refname --list 'v[0-9]*\.[0-9]*\.[0-9]'))
-# printf "Found ${allTags[*]} tags"
-# latestTag=${allTags[0]}
-# latestTimestamp=($(git tag --sort=-version:refname --list 'v[0-9]*\.[0-9]*\.[0-9]' --format '%(creatordate:unix)' | head -n 1))
-# latestTagTimestamp="${latestTag}_$latestTimestamp"
-
-# # There are at least 2 tags available at this point of time
-# secondToLatestTag=${allTags[1]}
-# secondToLatestTagTimestamp="${secondToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*\.[0-9]*\.[0-9]' --format '%(creatordate:unix)' | head -n 2 | tail -1)"
-
-# tagsInRewardInterval=()
-# tagsInRewardInterval+=($latestTagTimestamp)
-# tagsInRewardInterval+=($secondToLatestTagTimestamp)
-
-# if [ "$ELIGIBLE_NUMBER_OF_TAGS" -eq "3" ]; then
-#   thirdToLatestTag=${allTags[2]}
-#   thirdToLatestTagTimestamp="${thirdToLatestTag}_$(git tag --sort=-version:refname --list 'v[0-9]*\.[0-9]*\.[0-9]' --format '%(creatordate:unix)' | head -n 3 | tail -1)"
-#   tagsInRewardInterval+=($thirdToLatestTagTimestamp)
-# fi
-
-# # Converting array to string so we can pass to the rewards-requirements.ts
-# printf -v tags '%s|' "${tagsInRewardInterval[@]}"
-# tagsTrimmed="${tags%?}" # remove "|" at the end
-
-# # Removing created remote
-# git remote remove keep-core-repo
 
 # Run script
 printf "${LOG_START}Fetching peers data...${LOG_END}"

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -24,7 +24,6 @@ import {
   IS_UP_TIME_SATISFIED,
   IS_PRE_PARAMS_SATISFIED,
   IS_VERSION_SATISFIED,
-  ALLOWED_UPGRADE_DELAY,
   PRECISION,
   OPERATORS_SEARCH_QUERY_STEP,
   QUERY_RESOLUTION,
@@ -54,8 +53,8 @@ program
   .requiredOption("-a, --api <prometheus api>", "prometheus API")
   .requiredOption("-j, --job <prometheus job>", "prometheus job")
   .requiredOption(
-    "-r, --releases <client releases in a rewards interval>",
-    "client releases in a rewards interval"
+    "-v, --valid-versions <valid versions string>",
+    "valid versions string"
   )
   .requiredOption("-n, --network <name>", "network name")
   .requiredOption("-o, --output <file>", "output JSON file")
@@ -71,7 +70,7 @@ program
 const options = program.opts()
 const prometheusJob = options.job
 const prometheusAPI = options.api
-const clientReleases = options.releases.split("|") // sorted from latest to oldest
+const clientVersions = options.validVersions.split("|") // sorted from latest to oldest
 const startRewardsTimestamp = parseInt(options.startTimestamp)
 const endRewardsTimestamp = parseInt(options.endTimestamp)
 const startRewardsBlock = parseInt(options.startBlock)
@@ -341,20 +340,13 @@ export async function calculateRewards() {
 
     requirements.set(IS_PRE_PARAMS_SATISFIED, isPrePramsSatisfied)
 
-    // keep-core client already has at least 2 released versions
-    const latestClient = clientReleases[0].split("_")
-    const latestClientTag = latestClient[0]
-    const latestClientTagTimestamp = Number(latestClient[1])
-    const secondToLatestClient = clientReleases[1].split("_")
-    const secondToLatestClientTag = secondToLatestClient[0]
+    const validVersions = clientVersions.map((client: string) => {
+      return { version: client.split("_")[0], deadline: client.split("_")[1] }
+    })
 
-    const eligibleClientTags = [latestClientTag, secondToLatestClientTag]
-
-    if (clientReleases.length == 3) {
-      const thirdToLatestClient = clientReleases[2].split("_")
-      const thirdToLatestClientTag = thirdToLatestClient[0]
-      eligibleClientTags.push(thirdToLatestClientTag)
-    }
+    const validVersionsNames = validVersions.map(
+      (validVersion: any) => validVersion.version
+    )
 
     const instances = await processBuildVersions(
       operatorAddress,
@@ -362,67 +354,83 @@ export async function calculateRewards() {
       instancesData
     )
 
-    const upgradeCutoffDate = latestClientTagTimestamp + ALLOWED_UPGRADE_DELAY
     requirements.set(IS_VERSION_SATISFIED, true)
-    if (upgradeCutoffDate < startRewardsTimestamp) {
-      // E.g. Feb interval
-      // ---older eligible tags---|----------latest tag only--------------|
-      // ---|---------------------|---------|-----------------------------|--->
-      // latest tag             cutoff     Feb1                         Feb28
 
-      // All the instances must run on the latest version during the rewards
-      // interval in Feb.
+    // if there is only one valid version, all the instances must run on it
+    if (validVersions.length === 1) {
       for (let i = 0; i < instances.length; i++) {
-        if (instances[i].buildVersion != latestClientTag) {
+        if (
+          !checkMinorVersion(
+            validVersions[0].version,
+            instances[i].buildVersion
+          )
+        ) {
           requirements.set(IS_VERSION_SATISFIED, false)
         }
       }
-    } else if (upgradeCutoffDate < endRewardsTimestamp) {
+    } else if (validVersions.length > 1) {
+      // for simplicity purposes, if there is several deadlines, upgradeCutoffDate is the
+      // least restrictive deadline.
+      const upgradeCutoffDate = validVersions[1].deadline
+      const latestClientTag = validVersions[0].version
+
+      // if we have more than one valid version, we need to check if the instances did the update
+      // before the cutoff date
+      //
       // E.g. Feb interval
       // -----older eligible tags-----|----latest tag only----|
       // ----|---------|--------------|-----------------------|--->
       // latest tag   Feb1          cutoff                   Feb28
-
-      // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
-      // must run on the latest version
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (
-          instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
-          !instances[i].buildVersion.includes(latestClientTag)
-        ) {
-          // After the cutoff day a node operator still run an instance with an
-          // older version. No rewards.
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check further since at least one instance run on the
-          // older version after the cutoff day.
-          break
-        } else {
-          // It might happen that a node operator stopped an instance before the
-          // upgrade cutoff date that happens to be right before the interval
-          // end date. However, it might still be eligible for rewards because
-          // of the uptime requirement.
-          if (!eligibleClientTags.includes(instances[i].buildVersion)) {
+      if (upgradeCutoffDate < endRewardsTimestamp) {
+        // All the instances between (upgradeCutoffDate : endRewardsTimestamp]
+        // must run on the latest version
+        for (let i = instances.length - 1; i >= 0; i--) {
+          if (
+            instances[i].lastRegisteredTimestamp > upgradeCutoffDate &&
+            !checkMinorVersion(latestClientTag, instances[i].buildVersion)
+          ) {
+            // After the cutoff day a node operator still run an instance with an
+            // invalid version. No rewards.
             requirements.set(IS_VERSION_SATISFIED, false)
-            // No need to check other instances because at least one instance run
-            // on the older version than 2 latest allowed.
+            // No need to check further since at least one instance run on the
+            // older version after the cutoff day.
             break
+          } else {
+            // It might happen that a node operator stopped an instance before the
+            // upgrade cutoff date that happens to be right before the interval
+            // end date. However, it might still be eligible for rewards because
+            // of the uptime requirement.
+            // So it is still necessary to check if the instance is on valid versions list
+            if (
+              !validVersionsNames.some((version: string) =>
+                checkMinorVersion(version, instances[i].buildVersion)
+              )
+            ) {
+              requirements.set(IS_VERSION_SATISFIED, false)
+              // No need to check other instances because at least one instance run
+              // on a version that is no longer eligible in this rewards interval.
+              break
+            }
           }
         }
-      }
-    } else {
-      // E.g. Feb interval
-      // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
-      // --|-----------------------|---------------|------------|-->
-      //  Feb1                latest tag         Feb28        cutoff
+      } else {
+        // E.g. Feb interval
+        // ---older eligible tags----|-----older or latest tag----|---latest tag only--->
+        // --|-----------------------|---------------|------------|-->
+        //  Feb1                latest tag         Feb28        cutoff
 
-      // For simplicity purposes all the instances can run on any of the eligible
-      // versions.
-      for (let i = instances.length - 1; i >= 0; i--) {
-        if (!eligibleClientTags.includes(instances[i].buildVersion)) {
-          requirements.set(IS_VERSION_SATISFIED, false)
-          // No need to check other instances because at least one instance run
-          // on a version that is no longer eligible in this rewards interval.
-          break
+        // For simplicity purposes all the instances can run on any of the eligible versions
+        for (let i = instances.length - 1; i >= 0; i--) {
+          if (
+            !validVersionsNames.some((version: string) =>
+              checkMinorVersion(version, instances[i].buildVersion)
+            )
+          ) {
+            requirements.set(IS_VERSION_SATISFIED, false)
+            // No need to check other instances because at least one instance run
+            // on a version that is no longer eligible in this rewards interval.
+            break
+          }
         }
       }
     }
@@ -761,6 +769,13 @@ function convertToObject(map: Map<string, InstanceParams>) {
   })
 
   return obj
+}
+
+// Check if client version has the same major and minor than base version
+function checkMinorVersion(baseVersion: string, clientVersion: string) {
+  const minorBase = baseVersion.match(/[0-9]+\.[0-9]+/g)
+  const regex = new RegExp(`v${minorBase}\\.[0-9]+$`)
+  return regex.test(clientVersion)
 }
 
 async function queryPrometheus(url: string, params: any): Promise<any> {


### PR DESCRIPTION
### Context

tBTC client versioning scheme has slightly changed since the release of `v2.0.0`. Previous versions of the tBTC v2 client had a `-mX` suffix (`v2.0.0-m1`, `v2.0.0-m2`, and so on).  But this is no longer the case.

From now on, the versioning system will follow semantic versioning https://semver.org/ but without suffixes.

**Concerning the calculation of the rewards, the rule is that it is mandatory to update the client when new major and minor versions, but it is optional for new patch versions.**

### The change

Up to now, the script works in the following way: 

tBTC client versions are retrieved through the git tags of `keep-network/keep-core` repo. So, when a new version is released, the validity window of previous versions is calculated considering the creation tag date. This can be considered as not totally correct since we consider that the update grace period actually starts when the new release is announced in the Discord #announcement channel and this announcement is not usually made right after the creation of the tag. So it is very common to have to recalculate the update window on the script to adjust to the actual announcement date.

Additionally, the script loads the git tags of `keep-network/keep-core` repo in this repo. So, when developing the script or when it fails, it can happen that some git data is mixed in the local repo so that it may generate some unexpected behaviors during usual git operations.

### How this is solved

- Git tag timedates of the released versions are no longer taken into account for the rewards calculations. So `keep-network/keep-core` repo is not loaded.
- The valid versions for each rewards distribution are manually specified when calculating the rewards. Only major and minor versions are specified. Patch versions are not since updating clients to them is not mandatory.

The versions are specified following this schema:

```
<version1>|<version2>_<version2Deadline>|<version3>_<version3Dealine> ...
```

- The versions are sorted from latest to oldest.
- versionDeadline is the deadline in UNIX timestamp until this version is valid.

Examples:

- Only v2.1.0 (and patch versions v2.1.1, v2.1.2, etc) are valid: 
```
v2.1.0
```
- v2.1.x is the current version. v2.0.x is valid until 2024-06-01:
``` 
v2.1.0|v2.0.0_1717200000
```
- v2.2.x is the current version. v2.1.x is valid until 2024-06-01. v2.0.x is valid until 2024-05-28: 
```
v2.2.0|v2.1.0_1717200000|v2.0.0_1716854400
```