### PR TITLE
Fix: Penalty Skipping in tBTC Rewards Calculation

### DIFF
--- a/src/scripts/tbtcv2-rewards/rewards-constants.ts
+++ b/src/scripts/tbtcv2-rewards/rewards-constants.ts
@@ -11,3 +11,4 @@ export const HUNDRED = 100
 export const IS_VERSION_SATISFIED = "isVersionSatisfied"
 export const APR = 15 // percent
 export const SECONDS_IN_YEAR = 31536000
+export const INITIAL_REWARDS_TIMESTAMP = 1657843200 // e.g. 2022-07-15 00:00:00 UTC

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -30,7 +30,7 @@ import {
   HUNDRED,
   APR,
   SECONDS_IN_YEAR,
-  INITIAL_REWARDS_TIMESTAMP, // Make sure you have this exported in rewards-constants.ts
+  INITIAL_REWARDS_TIMESTAMP,
 } from "./rewards-constants"
 
 program

--- a/src/scripts/tbtcv2-rewards/rewards.ts
+++ b/src/scripts/tbtcv2-rewards/rewards.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { Contract } from "ethers"
 import { program } from "commander"
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
 import * as fs from "fs"
 import { ethers } from "ethers"
 import {
@@ -31,6 +33,8 @@ import {
   APR,
   SECONDS_IN_YEAR,
 } from "./rewards-constants"
+
+dayjs.extend(utc)
 
 program
   .version("0.0.1")
@@ -85,6 +89,27 @@ const prometheusAPIQuery = `${prometheusAPI}/query`
 // Go back in time relevant to the current date to get data for the exact
 // rewards interval dates.
 const offset = Math.floor(Date.now() / 1000) - endRewardsTimestamp
+
+// Convert epoch timestamp to YYYY-MM-DD for your distributions folder.
+const startDate = dayjs.unix(startRewardsTimestamp).utc().format("YYYY-MM-DD")
+// e.g. "2025-01-01"
+const lastDistributionPath = `distributions/${startDate}`
+
+const merkleDistFile = `${lastDistributionPath}/MerkleDist.json`
+let oldOperatorsSet = new Set<string>()
+
+// Load the old distribution's MerkleDist if it exists
+if (fs.existsSync(merkleDistFile)) {
+  const merkleDistData = JSON.parse(fs.readFileSync(merkleDistFile, "utf-8"))
+  // merkleDistData.claims = { "0xOperator1": {...}, "0xOperator2": {...}, ... }
+  const oldOperators = Object.keys(merkleDistData.claims) // array of addresses
+  oldOperatorsSet = new Set(oldOperators.map((addr) => addr.toLowerCase()))
+  console.log(
+    `Loaded ${oldOperatorsSet.size} old operators from ${merkleDistFile}.`
+  )
+} else {
+  console.log(`WARNING: No MerkleDist.json found at ${merkleDistFile}`)
+}
 
 type InstanceParams = {
   upTimePercent: number
@@ -633,13 +658,22 @@ async function checkUptime(
 
   // First registered 'up' metric in a given interval <start:end> for a given
   // operator. Start evaluating uptime from this point.
-  const firstRegisteredUptime = instances.reduce(
+  let firstRegisteredUptime = instances.reduce(
     (currentMin: number, instance: any) =>
       Math.min(instance.values[0][0], currentMin),
     Number.MAX_VALUE
   )
 
+  // If the operator is in last distribution, we treat them as continuing
+  // => They must be measured from the *start* of the period, not from their first heartbeat.
+  if (oldOperatorsSet.has(operatorAddress.toLowerCase())) {
+    firstRegisteredUptime = startRewardsTimestamp
+  }
+
   let uptimeSearchRange = endRewardsTimestamp - firstRegisteredUptime
+  if (uptimeSearchRange < 0) {
+    uptimeSearchRange = 0 // means they came online after period end, effectively 0
+  }
 
   const paramsSumUptimes = {
     query: `sum_over_time(up{chain_address="${operatorAddress}", job="${prometheusJob}"}

--- a/src/scripts/tbtcv2-rewards/tsconfig.json
+++ b/src/scripts/tbtcv2-rewards/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "outDir": "./dist",
     "strict": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true
+    "resolveJsonModule": true
   },
 }

--- a/src/scripts/tbtcv2-rewards/tsconfig.json
+++ b/src/scripts/tbtcv2-rewards/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "outDir": "./dist",
     "strict": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
 }


### PR DESCRIPTION
Closes #160

**A bug was identified in the tBTC rewards calculation script:**

If a node was online in the previous period but shut down before that period ended and re-started mid-way through the next period, the script treated it as a new operator.

Consequently, that operator skipped penalties for insufficient uptime, because the script’s Prometheus queries only looked for heartbeats within the current [start..end] rewards window.

**What Changed**

We now load the list of operators who received rewards in the previous period (i.e., the “old operators”), based on the same date as start-timestamp in distributions/<YYYY-MM-DD>/MerkleDist.json.

If the operator’s address is in that set, we treat them as “continuing” from the start of the new period (startRewardsTimestamp), rather than from their first detected heartbeat.

That means if they go offline at the end of the previous period and only rejoin halfway through the new period, they are penalized for missing heartbeats from [startRewardsTimestamp..theirActualReturnTime].

No Additional JSON or Environment Variable is needed—everything is done in rewards.ts by reading the MerkleDist.json from the last distribution folder.

**Notes**

This implementation solves the immediate exploit, preventing “returning” operators from being mistaken for brand-new ones - but only from the immediate previous month. If an operator ceased two months prior and returned mid-way through this month, it will be considered a brand-new operator.

Operators that change addresses between distributions might still “reset” their identity, unless we implement further checks at the staking level. That’s a separate corner case.

**Ready for Review**

Request: Please review the new logic in `rewards.ts` and confirm the revised uptime behavior matches expectations.