### PR TITLE
Fix capped to 15M test

### DIFF
--- a/src/scripts/check-last-dist.test.js
+++ b/src/scripts/check-last-dist.test.js
@@ -364,6 +364,7 @@ describe("Checking last TACo rewards distribution", () => {
         .times(0.25)
         .times(periodDuration)
         .div(31536000)
+        .decimalPlaces(0)
 
       Object.keys(earnedRewards).map((stProv) => {
         const earnedAmount = BigNumber(earnedRewards[stProv].amount)


### PR DESCRIPTION
This test compares the amount dumped to distribution files, that is rounded so it doesn't include decimal, with a max amount calculation that it does include decimal. This make the test to fail.