### PR TITLE
Rename the heartbeat-rituals input file

### DIFF
--- a/src/scripts/gen_rewards_dist.js
+++ b/src/scripts/gen_rewards_dist.js
@@ -22,7 +22,7 @@ async function main() {
   const endDate = new Date(endTime * 1000).toISOString().slice(0, 10)
   const distPath = `distributions/${endDate}`
   const tacoRewardsDetailsPath = `${distPath}/TACoRewardsDetails`
-  const heartbeatRitualsPath = "DKGHeartbeatRituals.json"
+  const heartbeatRitualsPath = "heartbeat-rituals.json"
   const lastDistPath = `distributions/${lastDistribution}`
   const distributionsFilePath = "distributions/distributions.json"
 


### PR DESCRIPTION
This file is generated by initiate_rituals script on nucypher-contracts repo. The name of this output file is 'heartbeat-rituals.json', so in order to simplify the rewards generation process, the expected file has been renamed to this one.