### PR TITLE
Use distribution file as trigger for workflow

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -5,7 +5,7 @@ run-name: Check New Rewards Distribution Calculation
 on:
     pull_request:
         paths:
-            - 'distributions/**'
+            - 'distributions/distributions.json'
 
 jobs:
     check_distribution:


### PR DESCRIPTION
Using the changes on `distribution.json` file as trigger for check-dist workflow instead of the whole `distributions/` folder will avoid the workflow to be run every time we upload a commit containing the results of heartbeat rounds.